### PR TITLE
feat: add savings reference line marker (closes #7)

### DIFF
--- a/src/Components/InterestGraph.tsx
+++ b/src/Components/InterestGraph.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { LineChart, LineChartProps } from "@mui/x-charts/LineChart";
+import { ChartsReferenceLine } from "@mui/x-charts";
 import { Paper, useTheme, useMediaQuery, Box, Typography } from "@mui/material";
 import { bankInfo } from "../logic/constants";
 import { lineColors, textColor } from "../consts/colors";
@@ -124,7 +125,17 @@ export const InterestGraph = ({ profile }: { profile: Profile }) => {
             fill: textColor,
           },
         }}
-      />
+      >
+        <ChartsReferenceLine
+          x={profile.Savings}
+          label="Your savings"
+          lineStyle={{
+            stroke: lineColors[0],
+            strokeWidth: 2,
+            strokeDasharray: "6 3",
+          }}
+        />
+      </LineChart>
       <Typography
         variant="caption"
         sx={{


### PR DESCRIPTION
Add a vertical dashed reference line on the InterestGraph chart at the user's current savings amount using MUI X Charts' built-in ChartsReferenceLine component. This gives the user a clear 'you are here' marker on the X axis.

Closes #7 