### PR TITLE
feat: shareable profile URLs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { Layout, WithInputs } from "./Layout";
 import { CurrentRatesTab } from "./pages/CurrentRatesTab";
@@ -7,11 +7,31 @@ import { BankDetailPage } from "./pages/BankDetailPage";
 import { FaqPage } from "./pages/FaqPage";
 import Profile, { NewProfile } from "./types/profile";
 import { STORE_KEY } from "./consts/keys";
+import { searchToProfile, profileToSearch } from "./logic/profileUrl";
 
 export const App = () => {
-  const localData = localStorage.getItem(STORE_KEY) ?? "";
-  const localValue = localData ? JSON.parse(localData) : NewProfile({});
-  const [currProfile, setCurrProfile] = useState<Profile>(localValue);
+  // 1. Determine initial profile: URL params > localStorage > defaults
+  const [currProfile, setCurrProfile] = useState<Profile>(() => {
+    const urlSearch = window.location.search;
+    if (urlSearch) {
+      const fromUrl = searchToProfile(urlSearch);
+      // Persist URL-derived profile so subsequent visits without URL still work
+      localStorage.setItem(STORE_KEY, JSON.stringify(fromUrl));
+      return fromUrl;
+    }
+    const localData = localStorage.getItem(STORE_KEY) ?? "";
+    return localData ? JSON.parse(localData) : NewProfile({});
+  });
+
+  // 2. Sync profile changes to localStorage + URL
+  useEffect(() => {
+    localStorage.setItem(STORE_KEY, JSON.stringify(currProfile));
+    const search = profileToSearch(currProfile);
+    const newUrl = search
+      ? `${window.location.pathname}${search}`
+      : window.location.pathname;
+    window.history.replaceState(null, "", newUrl);
+  }, [currProfile]);
 
   return (
     <BrowserRouter>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { Layout, WithInputs } from "./Layout";
 import { CurrentRatesTab } from "./pages/CurrentRatesTab";
@@ -9,21 +9,50 @@ import Profile, { NewProfile } from "./types/profile";
 import { STORE_KEY } from "./consts/keys";
 import { searchToProfile, profileToSearch } from "./logic/profileUrl";
 
+const defaults = NewProfile({});
+
 export const App = () => {
-  // 1. Determine initial profile: URL params > localStorage > defaults
+  const urlSearch = window.location.search;
+  const localStr = localStorage.getItem(STORE_KEY);
+  const localProfile: Profile = localStr ? JSON.parse(localStr) : defaults;
+  const urlProfile: Profile | null = urlSearch ? searchToProfile(urlSearch) : null;
+
+  // Conflict: URL profile exists, local has real data, and they differ
+  const hasConflict =
+    urlProfile !== null &&
+    localStr !== null &&
+    JSON.stringify(localProfile) !== JSON.stringify(defaults) &&
+    JSON.stringify(urlProfile) !== JSON.stringify(localProfile);
+
+  // Start with local profile; if no conflict, transparently load from URL
   const [currProfile, setCurrProfile] = useState<Profile>(() => {
-    const urlSearch = window.location.search;
-    if (urlSearch) {
-      const fromUrl = searchToProfile(urlSearch);
-      // Persist URL-derived profile so subsequent visits without URL still work
-      localStorage.setItem(STORE_KEY, JSON.stringify(fromUrl));
-      return fromUrl;
+    if (urlProfile && !hasConflict) {
+      localStorage.setItem(STORE_KEY, JSON.stringify(urlProfile));
+      return urlProfile;
     }
-    const localData = localStorage.getItem(STORE_KEY) ?? "";
-    return localData ? JSON.parse(localData) : NewProfile({});
+    return localProfile;
   });
 
-  // 2. Sync profile changes to localStorage + URL
+  // Pending URL profile waiting for user confirmation
+  const [pendingUrlProfile, setPendingUrlProfile] = useState<Profile | null>(
+    hasConflict ? urlProfile : null,
+  );
+
+  const onAcceptShared = useCallback(() => {
+    if (pendingUrlProfile) {
+      setCurrProfile(pendingUrlProfile);
+      localStorage.setItem(STORE_KEY, JSON.stringify(pendingUrlProfile));
+      setPendingUrlProfile(null);
+    }
+  }, [pendingUrlProfile]);
+
+  const onRejectShared = useCallback(() => {
+    setPendingUrlProfile(null);
+    // Clean URL params so the shared link doesn't re-trigger on refresh
+    window.history.replaceState(null, "", window.location.pathname);
+  }, []);
+
+  // Sync profile changes to localStorage + URL
   useEffect(() => {
     localStorage.setItem(STORE_KEY, JSON.stringify(currProfile));
     const search = profileToSearch(currProfile);
@@ -38,7 +67,13 @@ export const App = () => {
       <Routes>
         <Route
           element={
-            <Layout currProfile={currProfile} setCurrProfile={setCurrProfile} />
+            <Layout
+              currProfile={currProfile}
+              setCurrProfile={setCurrProfile}
+              pendingUrlProfile={pendingUrlProfile}
+              onAcceptShared={onAcceptShared}
+              onRejectShared={onRejectShared}
+            />
           }
         >
           {/* Pages that need the savings inputs */}

--- a/src/Components/Alert.tsx
+++ b/src/Components/Alert.tsx
@@ -20,9 +20,6 @@ export const WebAlert = ({
       severity={severity}
       icon={<Check fontSize="inherit" />}
       sx={{
-        position: "fixed",
-        bottom: "10px",
-        right: "10px",
         color: "#fff",
         borderRadius: "8px",
         boxShadow: "0px 4px 10px rgba(0, 0, 0, 0.2)",

--- a/src/Components/Inputs.test.tsx
+++ b/src/Components/Inputs.test.tsx
@@ -10,6 +10,9 @@ describe("Form Inputs", () => {
       <FormInputs
         currProfile={NewProfile({})}
         setCurrProfile={(_: Profile) => {}}
+        pendingUrlProfile={null}
+        onAcceptShared={() => {}}
+        onRejectShared={() => {}}
       ></FormInputs>,
     ).asFragment();
     expect(tree).toMatchSnapshot();
@@ -29,6 +32,9 @@ describe("Form Inputs", () => {
           GiroTransactions: 0,
         })}
         setCurrProfile={(_: Profile) => {}}
+        pendingUrlProfile={null}
+        onAcceptShared={() => {}}
+        onRejectShared={() => {}}
       ></FormInputs>,
     ).asFragment();
     expect(tree).toMatchSnapshot();

--- a/src/Components/Inputs.tsx
+++ b/src/Components/Inputs.tsx
@@ -10,7 +10,7 @@ import {
   Typography,
   Chip,
 } from "@mui/material";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 import type Profile from "../types/profile";
 import { NewProfile } from "../types/profile";
@@ -27,6 +27,14 @@ import { WebAlert } from "./Alert";
 import { booleanInputs, numericalInputs } from "./InputValues";
 import { ShareButton } from "./ShareButton";
 import { SharedProfileDialog } from "./SharedProfileDialog";
+import { NotificationStack } from "./NotificationStack";
+import type { AlertColor } from "@mui/material";
+
+interface Notification {
+  id: number;
+  message: string;
+  severity: AlertColor;
+}
 
 interface FormInput {
   currProfile: Profile;
@@ -43,24 +51,33 @@ export const FormInputs = ({
   onAcceptShared,
   onRejectShared,
 }: FormInput) => {
-  const [hideModel, setHideModal] = useState<boolean>(true);
-  const [modelMsg, setModalMsg] = useState<string>("");
   const [profile, setProfile] = useState<Profile>(currProfile);
-  const [copiedMsg, setCopiedMsg] = useState(false);
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const nextId = useRef(0);
 
   useEffect(() => {
     localStorage.setItem(STORE_KEY, JSON.stringify(currProfile));
     setProfile(currProfile);
   }, [currProfile]);
 
+  const addNotification = useCallback(
+    (message: string, severity: AlertColor, duration = 3000) => {
+      const id = nextId.current++;
+      setNotifications((prev) => [...prev, { id, message, severity }]);
+      setTimeout(() => {
+        setNotifications((prev) => prev.filter((n) => n.id !== id));
+      }, duration);
+    },
+    [],
+  );
+
+  const dismissNotification = useCallback((id: number) => {
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+  }, []);
+
   const onClear = () => {
     setCurrProfile(NewProfile({}));
-    setModalMsg("Cleared");
-    setHideModal(false);
-    setTimeout(() => {
-      if (!hideModel) return;
-      setHideModal(true);
-    }, 1500);
+    addNotification("Cleared", "info");
   };
 
   return (
@@ -130,7 +147,9 @@ export const FormInputs = ({
       >
         <ShareButton
           profile={currProfile}
-          onCopied={() => setCopiedMsg(true)}
+          onCopied={() =>
+            addNotification("Profile URL copied to clipboard!", "success")
+          }
         />
         <Button
           key="clear-btn"
@@ -163,24 +182,18 @@ export const FormInputs = ({
           }}
         />
       </Box>
-      {!hideModel && (
-        <WebAlert
-          hideModel={hideModel}
-          severity={"info"}
-          onClose={() => setHideModal(true)}
-        >
-          {modelMsg}
-        </WebAlert>
-      )}
-      {copiedMsg && (
-        <WebAlert
-          hideModel={false}
-          severity="success"
-          onClose={() => setCopiedMsg(false)}
-        >
-          Profile URL copied to clipboard!
-        </WebAlert>
-      )}
+      <NotificationStack>
+        {notifications.map((n) => (
+          <WebAlert
+            key={n.id}
+            hideModel={false}
+            severity={n.severity}
+            onClose={() => dismissNotification(n.id)}
+          >
+            {n.message}
+          </WebAlert>
+        ))}
+      </NotificationStack>
     </>
   );
 };

--- a/src/Components/Inputs.tsx
+++ b/src/Components/Inputs.tsx
@@ -46,6 +46,7 @@ export const FormInputs = ({
   const [hideModel, setHideModal] = useState<boolean>(true);
   const [modelMsg, setModalMsg] = useState<string>("");
   const [profile, setProfile] = useState<Profile>(currProfile);
+  const [copiedMsg, setCopiedMsg] = useState(false);
 
   useEffect(() => {
     localStorage.setItem(STORE_KEY, JSON.stringify(currProfile));
@@ -127,7 +128,10 @@ export const FormInputs = ({
           gap: "15px",
         }}
       >
-        <ShareButton profile={currProfile} />
+        <ShareButton
+          profile={currProfile}
+          onCopied={() => setCopiedMsg(true)}
+        />
         <Button
           key="clear-btn"
           sx={{
@@ -166,6 +170,15 @@ export const FormInputs = ({
           onClose={() => setHideModal(true)}
         >
           {modelMsg}
+        </WebAlert>
+      )}
+      {copiedMsg && (
+        <WebAlert
+          hideModel={false}
+          severity="success"
+          onClose={() => setCopiedMsg(false)}
+        >
+          Profile URL copied to clipboard!
         </WebAlert>
       )}
     </>

--- a/src/Components/Inputs.tsx
+++ b/src/Components/Inputs.tsx
@@ -66,6 +66,8 @@ export const FormInputs = ({
     <>
       <SharedProfileDialog
         open={pendingUrlProfile !== null}
+        currProfile={currProfile}
+        pendingProfile={pendingUrlProfile ?? currProfile}
         onAccept={onAcceptShared}
         onReject={onRejectShared}
       />

--- a/src/Components/Inputs.tsx
+++ b/src/Components/Inputs.tsx
@@ -26,13 +26,23 @@ import type { Field } from "./types";
 import { WebAlert } from "./Alert";
 import { booleanInputs, numericalInputs } from "./InputValues";
 import { ShareButton } from "./ShareButton";
+import { SharedProfileDialog } from "./SharedProfileDialog";
 
 interface FormInput {
   currProfile: Profile;
   setCurrProfile: (_: Profile) => void;
+  pendingUrlProfile: Profile | null;
+  onAcceptShared: () => void;
+  onRejectShared: () => void;
 }
 
-export const FormInputs = ({ currProfile, setCurrProfile }: FormInput) => {
+export const FormInputs = ({
+  currProfile,
+  setCurrProfile,
+  pendingUrlProfile,
+  onAcceptShared,
+  onRejectShared,
+}: FormInput) => {
   const [hideModel, setHideModal] = useState<boolean>(true);
   const [modelMsg, setModalMsg] = useState<string>("");
   const [profile, setProfile] = useState<Profile>(currProfile);
@@ -54,6 +64,11 @@ export const FormInputs = ({ currProfile, setCurrProfile }: FormInput) => {
 
   return (
     <>
+      <SharedProfileDialog
+        open={pendingUrlProfile !== null}
+        onAccept={onAcceptShared}
+        onReject={onRejectShared}
+      />
       <FormControl
         sx={{
           display: "flex",

--- a/src/Components/Inputs.tsx
+++ b/src/Components/Inputs.tsx
@@ -25,6 +25,7 @@ import {
 import type { Field } from "./types";
 import { WebAlert } from "./Alert";
 import { booleanInputs, numericalInputs } from "./InputValues";
+import { ShareButton } from "./ShareButton";
 
 interface FormInput {
   currProfile: Profile;
@@ -109,6 +110,7 @@ export const FormInputs = ({ currProfile, setCurrProfile }: FormInput) => {
           gap: "15px",
         }}
       >
+        <ShareButton profile={currProfile} />
         <Button
           key="clear-btn"
           sx={{

--- a/src/Components/NotificationStack.tsx
+++ b/src/Components/NotificationStack.tsx
@@ -1,0 +1,31 @@
+import { Box } from "@mui/material";
+import type { ReactNode } from "react";
+
+interface NotificationStackProps {
+  children: ReactNode;
+}
+
+/**
+ * Fixed-position container that stacks notifications vertically
+ * at the bottom-right of the viewport.
+ * Add more notifications and they automatically stack.
+ */
+export const NotificationStack = ({ children }: NotificationStackProps) => (
+  <Box
+    sx={{
+      position: "fixed",
+      bottom: "16px",
+      right: "16px",
+      display: "flex",
+      flexDirection: "column",
+      gap: "8px",
+      zIndex: 9999,
+      pointerEvents: "none",
+      "& > *": {
+        pointerEvents: "auto",
+      },
+    }}
+  >
+    {children}
+  </Box>
+);

--- a/src/Components/ShareButton.tsx
+++ b/src/Components/ShareButton.tsx
@@ -1,0 +1,58 @@
+import { useState, useCallback } from "react";
+import { Button, Box } from "@mui/material";
+import ShareOutlinedIcon from "@mui/icons-material/ShareOutlined";
+import CheckIcon from "@mui/icons-material/Check";
+import { primaryColor, textColor, bgColor } from "../consts/colors";
+import type Profile from "../types/profile";
+import { profileToUrl } from "../logic/profileUrl";
+
+interface ShareButtonProps {
+  profile: Profile;
+}
+
+export const ShareButton = ({ profile }: ShareButtonProps) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleShare = useCallback(async () => {
+    const url = profileToUrl(profile);
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback for older browsers / non-HTTPS contexts
+      const textarea = document.createElement("textarea");
+      textarea.value = url;
+      textarea.style.position = "fixed";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, [profile]);
+
+  return (
+    <Button
+      type="button"
+      onClick={handleShare}
+      startIcon={copied ? <CheckIcon /> : <ShareOutlinedIcon />}
+      sx={{
+        backgroundColor: copied ? "#2e7d32" : bgColor,
+        color: textColor,
+        padding: "10px 20px",
+        borderRadius: "8px",
+        border: `1px solid ${copied ? "#2e7d32" : primaryColor}`,
+        "&:hover": {
+          backgroundColor: copied
+            ? "#2e7d32"
+            : "rgba(255,255,255,0.08)",
+        },
+      }}
+    >
+      {copied ? "Copied!" : "Share"}
+    </Button>
+  );
+};

--- a/src/Components/ShareButton.tsx
+++ b/src/Components/ShareButton.tsx
@@ -8,9 +8,10 @@ import { profileToUrl } from "../logic/profileUrl";
 
 interface ShareButtonProps {
   profile: Profile;
+  onCopied?: () => void;
 }
 
-export const ShareButton = ({ profile }: ShareButtonProps) => {
+export const ShareButton = ({ profile, onCopied }: ShareButtonProps) => {
   const [copied, setCopied] = useState(false);
 
   const handleShare = useCallback(async () => {
@@ -18,6 +19,7 @@ export const ShareButton = ({ profile }: ShareButtonProps) => {
     try {
       await navigator.clipboard.writeText(url);
       setCopied(true);
+      onCopied?.();
       setTimeout(() => setCopied(false), 2000);
     } catch {
       // Fallback for older browsers / non-HTTPS contexts
@@ -30,9 +32,10 @@ export const ShareButton = ({ profile }: ShareButtonProps) => {
       document.execCommand("copy");
       document.body.removeChild(textarea);
       setCopied(true);
+      onCopied?.();
       setTimeout(() => setCopied(false), 2000);
     }
-  }, [profile]);
+  }, [profile, onCopied]);
 
   return (
     <Button

--- a/src/Components/SharedProfileDialog.tsx
+++ b/src/Components/SharedProfileDialog.tsx
@@ -1,11 +1,5 @@
-import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-} from "@mui/material";
+import { Button, Alert, Collapse } from "@mui/material";
+import { Close } from "@mui/icons-material";
 
 interface Props {
   open: boolean;
@@ -14,27 +8,50 @@ interface Props {
 }
 
 /**
- * Confirmation dialog shown when a shared profile URL would overwrite
- * the user's existing saved profile.
+ * Non-blocking notification card shown when a shared profile URL would
+ * overwrite the user's existing saved profile. Styled consistently with
+ * the existing WebAlert notification cards.
  */
 export const SharedProfileDialog = ({ open, onAccept, onReject }: Props) => (
-  <Dialog open={open} onClose={onReject} aria-labelledby="shared-profile-dialog">
-    <DialogTitle id="shared-profile-dialog">
-      Shared profile detected
-    </DialogTitle>
-    <DialogContent>
-      <DialogContentText>
-        This link contains a shared profile. Loading it will replace your
-        current saved inputs. Do you want to load the shared profile?
-      </DialogContentText>
-    </DialogContent>
-    <DialogActions>
-      <Button onClick={onReject} color="inherit">
-        Keep my profile
-      </Button>
-      <Button onClick={onAccept} variant="contained" autoFocus>
-        Load shared profile
-      </Button>
-    </DialogActions>
-  </Dialog>
+  <Collapse in={open}>
+    <Alert
+      severity="warning"
+      sx={{
+        position: "fixed",
+        bottom: "10px",
+        right: "10px",
+        maxWidth: "400px",
+        color: "#fff",
+        borderRadius: "8px",
+        boxShadow: "0px 4px 10px rgba(0, 0, 0, 0.2)",
+        zIndex: 1300,
+      }}
+      action={
+        <>
+          <Button
+            size="small"
+            color="inherit"
+            onClick={onReject}
+            sx={{ color: "#fff" }}
+          >
+            Keep mine
+          </Button>
+          <Button
+            size="small"
+            variant="outlined"
+            onClick={onAccept}
+            sx={{
+              color: "#fff",
+              borderColor: "rgba(255,255,255,0.5)",
+              ml: 1,
+            }}
+          >
+            Load
+          </Button>
+        </>
+      }
+    >
+      Shared profile detected — load it?
+    </Alert>
+  </Collapse>
 );

--- a/src/Components/SharedProfileDialog.tsx
+++ b/src/Components/SharedProfileDialog.tsx
@@ -1,0 +1,40 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from "@mui/material";
+
+interface Props {
+  open: boolean;
+  onAccept: () => void;
+  onReject: () => void;
+}
+
+/**
+ * Confirmation dialog shown when a shared profile URL would overwrite
+ * the user's existing saved profile.
+ */
+export const SharedProfileDialog = ({ open, onAccept, onReject }: Props) => (
+  <Dialog open={open} onClose={onReject} aria-labelledby="shared-profile-dialog">
+    <DialogTitle id="shared-profile-dialog">
+      Shared profile detected
+    </DialogTitle>
+    <DialogContent>
+      <DialogContentText>
+        This link contains a shared profile. Loading it will replace your
+        current saved inputs. Do you want to load the shared profile?
+      </DialogContentText>
+    </DialogContent>
+    <DialogActions>
+      <Button onClick={onReject} color="inherit">
+        Keep my profile
+      </Button>
+      <Button onClick={onAccept} variant="contained" autoFocus>
+        Load shared profile
+      </Button>
+    </DialogActions>
+  </Dialog>
+);

--- a/src/Components/SharedProfileDialog.tsx
+++ b/src/Components/SharedProfileDialog.tsx
@@ -1,57 +1,139 @@
-import { Button, Alert, Collapse } from "@mui/material";
-import { Close } from "@mui/icons-material";
+import { Button, Alert, Collapse, Table, TableBody, TableCell, TableRow, Typography } from "@mui/material";
+import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
+import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
+import RemoveIcon from "@mui/icons-material/Remove";
+import type Profile from "../types/profile";
 
 interface Props {
   open: boolean;
+  currProfile: Profile;
+  pendingProfile: Profile;
   onAccept: () => void;
   onReject: () => void;
 }
 
+interface FieldMeta {
+  label: string;
+  key: keyof Profile;
+  isBoolean: boolean;
+}
+
+const FIELDS: FieldMeta[] = [
+  { key: "Savings", label: "Savings", isBoolean: false },
+  { key: "Age", label: "Age", isBoolean: false },
+  { key: "Salary", label: "Salary", isBoolean: false },
+  { key: "Spending", label: "Spending", isBoolean: false },
+  { key: "Investment", label: "Investment", isBoolean: false },
+  { key: "Insurance", label: "Insurance", isBoolean: false },
+  { key: "GiroTransactions", label: "GIRO Txn", isBoolean: false },
+  { key: "MonthlyAccIncrease", label: "Acc Increase", isBoolean: false },
+  { key: "LoanInstallment", label: "Loan Install", isBoolean: false },
+  { key: "OneTimeLoan", label: "One-time Loan", isBoolean: false },
+  { key: "IsNTUCMember", label: "NTUC Member", isBoolean: true },
+];
+
+const fmtCurrency = (v: number): string =>
+  v === 0 ? "$0" : `$${v.toLocaleString()}`;
+
+const fmtValue = (v: Profile[keyof Profile], isBoolean: boolean): string => {
+  if (isBoolean) return v ? "Yes" : "No";
+  return fmtCurrency(v as number);
+};
+
+const diffIcon = (curr: Profile[keyof Profile], pending: Profile[keyof Profile], isBoolean: boolean) => {
+  if (isBoolean) {
+    if (curr === pending) return <RemoveIcon fontSize="inherit" sx={{ opacity: 0.4 }} />;
+    return pending ? <ArrowUpwardIcon fontSize="inherit" color="success" /> : <ArrowDownwardIcon fontSize="inherit" color="error" />;
+  }
+  const c = curr as number;
+  const p = pending as number;
+  if (c === p) return null;
+  return p > c
+    ? <ArrowUpwardIcon fontSize="inherit" color="success" />
+    : <ArrowDownwardIcon fontSize="inherit" color="error" />;
+};
+
+const tableCellSx = {
+  py: 0.3,
+  px: 1,
+  borderBottom: "1px solid rgba(255,255,255,0.08)",
+  color: "inherit",
+  fontSize: "0.78rem",
+};
+
 /**
  * Non-blocking notification card shown when a shared profile URL would
- * overwrite the user's existing saved profile. Styled consistently with
- * the existing WebAlert notification cards.
+ * overwrite the user's existing saved profile. Shows a field-by-field
+ * diff so the user can decide whether to load the shared profile.
  */
-export const SharedProfileDialog = ({ open, onAccept, onReject }: Props) => (
-  <Collapse in={open}>
-    <Alert
-      severity="warning"
-      sx={{
-        position: "fixed",
-        bottom: "10px",
-        right: "10px",
-        maxWidth: "400px",
-        color: "#fff",
-        borderRadius: "8px",
-        boxShadow: "0px 4px 10px rgba(0, 0, 0, 0.2)",
-        zIndex: 1300,
-      }}
-      action={
-        <>
-          <Button
-            size="small"
-            color="inherit"
-            onClick={onReject}
-            sx={{ color: "#fff" }}
-          >
-            Keep mine
-          </Button>
-          <Button
-            size="small"
-            variant="outlined"
-            onClick={onAccept}
-            sx={{
-              color: "#fff",
-              borderColor: "rgba(255,255,255,0.5)",
-              ml: 1,
-            }}
-          >
-            Load
-          </Button>
-        </>
-      }
-    >
-      Shared profile detected — load it?
-    </Alert>
-  </Collapse>
-);
+export const SharedProfileDialog = ({ open, currProfile, pendingProfile, onAccept, onReject }: Props) => {
+  const diffs = FIELDS.filter(
+    ({ key, isBoolean }) => currProfile[key] !== pendingProfile[key]
+  );
+
+  return (
+    <Collapse in={open}>
+      <Alert
+        severity="warning"
+        sx={{
+          position: "fixed",
+          bottom: "10px",
+          right: "10px",
+          maxWidth: "480px",
+          color: "#fff",
+          borderRadius: "8px",
+          boxShadow: "0px 4px 12px rgba(0, 0, 0, 0.3)",
+          zIndex: 1300,
+        }}
+        action={
+          <>
+            <Button
+              size="small"
+              color="inherit"
+              onClick={onReject}
+              sx={{ color: "#fff" }}
+            >
+              Keep mine
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              onClick={onAccept}
+              sx={{
+                color: "#fff",
+                borderColor: "rgba(255,255,255,0.5)",
+                ml: 1,
+              }}
+            >
+              Load
+            </Button>
+          </>
+        }
+      >
+        <Typography variant="body2" sx={{ mb: 0.5, fontWeight: 600 }}>
+          Shared profile detected — {diffs.length} field{diffs.length !== 1 ? "s" : ""} differ{open ? "" : ""}
+        </Typography>
+        {diffs.length > 0 && (
+          <Table size="small" sx={{ mb: 0.5 }}>
+            <TableBody>
+              {diffs.map(({ key, label, isBoolean }) => (
+                <TableRow key={key}>
+                  <TableCell sx={{ ...tableCellSx, fontWeight: 500 }}>{label}</TableCell>
+                  <TableCell sx={{ ...tableCellSx, textDecoration: "line-through", opacity: 0.6 }}>
+                    {fmtValue(currProfile[key], isBoolean)}
+                  </TableCell>
+                  <TableCell sx={{ ...tableCellSx, width: 24, textAlign: "center" }}>
+                    {diffIcon(currProfile[key], pendingProfile[key], isBoolean)}
+                  </TableCell>
+                  <TableCell sx={{ ...tableCellSx, fontWeight: 600 }}>
+                    {fmtValue(pendingProfile[key], isBoolean)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </Alert>
+    </Collapse>
+  );
+};

--- a/src/Components/SharedProfileDialog.tsx
+++ b/src/Components/SharedProfileDialog.tsx
@@ -1,4 +1,15 @@
-import { Button, Alert, Collapse, Table, TableBody, TableCell, TableRow, Typography } from "@mui/material";
+import {
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+  Typography,
+} from "@mui/material";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import RemoveIcon from "@mui/icons-material/Remove";
@@ -40,89 +51,83 @@ const fmtValue = (v: Profile[keyof Profile], isBoolean: boolean): string => {
   return fmtCurrency(v as number);
 };
 
-const diffIcon = (curr: Profile[keyof Profile], pending: Profile[keyof Profile], isBoolean: boolean) => {
+const diffIcon = (
+  curr: Profile[keyof Profile],
+  pending: Profile[keyof Profile],
+  isBoolean: boolean,
+) => {
   if (isBoolean) {
-    if (curr === pending) return <RemoveIcon fontSize="inherit" sx={{ opacity: 0.4 }} />;
-    return pending ? <ArrowUpwardIcon fontSize="inherit" color="success" /> : <ArrowDownwardIcon fontSize="inherit" color="error" />;
+    if (curr === pending)
+      return <RemoveIcon fontSize="inherit" sx={{ opacity: 0.4 }} />;
+    return pending ? (
+      <ArrowUpwardIcon fontSize="inherit" color="success" />
+    ) : (
+      <ArrowDownwardIcon fontSize="inherit" color="error" />
+    );
   }
   const c = curr as number;
   const p = pending as number;
   if (c === p) return null;
-  return p > c
-    ? <ArrowUpwardIcon fontSize="inherit" color="success" />
-    : <ArrowDownwardIcon fontSize="inherit" color="error" />;
+  return p > c ? (
+    <ArrowUpwardIcon fontSize="inherit" color="success" />
+  ) : (
+    <ArrowDownwardIcon fontSize="inherit" color="error" />
+  );
 };
 
 const tableCellSx = {
-  py: 0.3,
-  px: 1,
-  borderBottom: "1px solid rgba(255,255,255,0.08)",
-  color: "inherit",
-  fontSize: "0.78rem",
+  py: 0.6,
+  px: 1.5,
+  borderBottom: "1px solid rgba(0,0,0,0.08)",
+  fontSize: "0.82rem",
 };
 
 /**
- * Non-blocking notification card shown when a shared profile URL would
- * overwrite the user's existing saved profile. Shows a field-by-field
- * diff so the user can decide whether to load the shared profile.
+ * Blocking modal shown when a shared profile URL would overwrite the
+ * user's existing saved profile. Shows a field-by-field diff so the
+ * user can decide whether to load the shared profile.
  */
-export const SharedProfileDialog = ({ open, currProfile, pendingProfile, onAccept, onReject }: Props) => {
+export const SharedProfileDialog = ({
+  open,
+  currProfile,
+  pendingProfile,
+  onAccept,
+  onReject,
+}: Props) => {
   const diffs = FIELDS.filter(
-    ({ key, isBoolean }) => currProfile[key] !== pendingProfile[key]
+    ({ key }) => currProfile[key] !== pendingProfile[key],
   );
 
   return (
-    <Collapse in={open}>
-      <Alert
-        severity="warning"
-        sx={{
-          position: "fixed",
-          bottom: "10px",
-          right: "10px",
-          maxWidth: "480px",
-          color: "#fff",
-          borderRadius: "8px",
-          boxShadow: "0px 4px 12px rgba(0, 0, 0, 0.3)",
-          zIndex: 1300,
-        }}
-        action={
-          <>
-            <Button
-              size="small"
-              color="inherit"
-              onClick={onReject}
-              sx={{ color: "#fff" }}
-            >
-              Keep mine
-            </Button>
-            <Button
-              size="small"
-              variant="outlined"
-              onClick={onAccept}
-              sx={{
-                color: "#fff",
-                borderColor: "rgba(255,255,255,0.5)",
-                ml: 1,
-              }}
-            >
-              Load
-            </Button>
-          </>
-        }
-      >
-        <Typography variant="body2" sx={{ mb: 0.5, fontWeight: 600 }}>
-          Shared profile detected — {diffs.length} field{diffs.length !== 1 ? "s" : ""} differ{open ? "" : ""}
+    <Dialog open={open} onClose={onReject} maxWidth="xs" fullWidth>
+      <DialogTitle sx={{ pb: 0 }}>
+        Shared Profile Detected
+      </DialogTitle>
+      <DialogContent sx={{ pt: 1 }}>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+          The shared profile has {diffs.length} field
+          {diffs.length !== 1 ? "s" : ""} different from yours:
         </Typography>
         {diffs.length > 0 && (
-          <Table size="small" sx={{ mb: 0.5 }}>
+          <Table size="small">
             <TableBody>
               {diffs.map(({ key, label, isBoolean }) => (
                 <TableRow key={key}>
-                  <TableCell sx={{ ...tableCellSx, fontWeight: 500 }}>{label}</TableCell>
-                  <TableCell sx={{ ...tableCellSx, textDecoration: "line-through", opacity: 0.6 }}>
+                  <TableCell sx={{ ...tableCellSx, fontWeight: 500 }}>
+                    {label}
+                  </TableCell>
+                  <TableCell
+                    sx={{
+                      ...tableCellSx,
+                      textDecoration: "line-through",
+                      opacity: 0.5,
+                    }}
+                  >
                     {fmtValue(currProfile[key], isBoolean)}
                   </TableCell>
-                  <TableCell sx={{ ...tableCellSx, width: 24, textAlign: "center" }}>
+                  <TableCell
+                    sx={{ ...tableCellSx, width: 28, textAlign: "center" }}
+                  >
                     {diffIcon(currProfile[key], pendingProfile[key], isBoolean)}
                   </TableCell>
                   <TableCell sx={{ ...tableCellSx, fontWeight: 600 }}>
@@ -133,7 +138,15 @@ export const SharedProfileDialog = ({ open, currProfile, pendingProfile, onAccep
             </TableBody>
           </Table>
         )}
-      </Alert>
-    </Collapse>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onReject} color="inherit">
+          Keep Current
+        </Button>
+        <Button onClick={onAccept} variant="contained">
+          Load Shared
+        </Button>
+      </DialogActions>
+    </Dialog>
   );
 };

--- a/src/Components/__snapshots__/Alert.test.tsx.snap
+++ b/src/Components/__snapshots__/Alert.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Web Alert > should match snapshot 1`] = `
         class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
       >
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorSuccess MuiAlert-standard css-1ouial1-MuiPaper-root-MuiAlert-root"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorSuccess MuiAlert-standard css-19lpqqk-MuiPaper-root-MuiAlert-root"
           role="alert"
           style="--Paper-shadow: none;"
         >

--- a/src/Components/__snapshots__/Inputs.test.tsx.snap
+++ b/src/Components/__snapshots__/Inputs.test.tsx.snap
@@ -3,67 +3,6 @@
 exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
 <DocumentFragment>
   <div
-    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-cwrbtg-MuiCollapse-root"
-    style="min-height: 0px;"
-  >
-    <div
-      class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
-    >
-      <div
-        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
-      >
-        <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standard css-btxnfn-MuiPaper-root-MuiAlert-root"
-          role="alert"
-          style="--Paper-shadow: none;"
-        >
-          <div
-            class="MuiAlert-icon css-vab54s-MuiAlert-icon"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1ckov0h-MuiSvgIcon-root"
-              data-testid="ReportProblemOutlinedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
-              />
-            </svg>
-          </div>
-          <div
-            class="MuiAlert-message css-zioonp-MuiAlert-message"
-          >
-            <p
-              class="MuiTypography-root MuiTypography-body2 css-7mxp11-MuiTypography-root"
-            >
-              Shared profile detected — 0 fields differ
-            </p>
-          </div>
-          <div
-            class="MuiAlert-action css-rgppqo-MuiAlert-action"
-          >
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeSmall MuiButton-colorInherit css-1fnilek-MuiButtonBase-root-MuiButton-root"
-              tabindex="0"
-              type="button"
-            >
-              Keep mine
-            </button>
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-sizeSmall MuiButton-colorPrimary css-ir2doi-MuiButtonBase-root-MuiButton-root"
-              tabindex="0"
-              type="button"
-            >
-              Load
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
     class="MuiFormControl-root css-1hr5jum-MuiFormControl-root"
   >
     <div
@@ -75,8 +14,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_2_"
-          id="_r_2_-label"
+          for="_r_1_"
+          id="_r_1_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -94,7 +33,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_2_"
+            id="_r_1_"
             placeholder="To be deposited at bank"
             type="number"
             value=""
@@ -127,8 +66,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_3_"
-          id="_r_3_-label"
+          for="_r_2_"
+          id="_r_2_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -146,7 +85,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_3_"
+            id="_r_2_"
             placeholder="Current age"
             type="number"
             value=""
@@ -179,8 +118,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_4_"
-          id="_r_4_-label"
+          for="_r_3_"
+          id="_r_3_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -198,7 +137,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_4_"
+            id="_r_3_"
             placeholder="Credited to bank monthly"
             type="number"
             value=""
@@ -231,8 +170,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_5_"
-          id="_r_5_-label"
+          for="_r_4_"
+          id="_r_4_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -250,7 +189,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_5_"
+            id="_r_4_"
             placeholder="Pay to bank yearly"
             type="number"
             value=""
@@ -283,8 +222,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_6_"
-          id="_r_6_-label"
+          for="_r_5_"
+          id="_r_5_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -302,7 +241,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_6_"
+            id="_r_5_"
             placeholder="Pay to bank yearly"
             type="number"
             value=""
@@ -335,8 +274,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_7_"
-          id="_r_7_-label"
+          for="_r_6_"
+          id="_r_6_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -354,7 +293,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_7_"
+            id="_r_6_"
             placeholder="On eligible cards monthly"
             type="number"
             value=""
@@ -387,8 +326,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_8_"
-          id="_r_8_-label"
+          for="_r_7_"
+          id="_r_7_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -406,7 +345,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_8_"
+            id="_r_7_"
             placeholder="No. of GIRO Transactions"
             type="number"
             value=""
@@ -439,8 +378,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_9_"
-          id="_r_9_-label"
+          for="_r_8_"
+          id="_r_8_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -458,7 +397,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_9_"
+            id="_r_8_"
             placeholder="Balance increase monthly"
             type="number"
             value=""
@@ -491,8 +430,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_a_"
-          id="_r_a_-label"
+          for="_r_9_"
+          id="_r_9_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -510,7 +449,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_a_"
+            id="_r_9_"
             placeholder="Monthly loan payment"
             type="number"
             value=""
@@ -543,8 +482,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_b_"
-          id="_r_b_-label"
+          for="_r_a_"
+          id="_r_a_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -562,7 +501,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_b_"
+            id="_r_a_"
             placeholder="Additional 1 time loan"
             type="number"
             value=""
@@ -689,67 +628,6 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
 exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
 <DocumentFragment>
   <div
-    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-cwrbtg-MuiCollapse-root"
-    style="min-height: 0px;"
-  >
-    <div
-      class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
-    >
-      <div
-        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
-      >
-        <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standard css-btxnfn-MuiPaper-root-MuiAlert-root"
-          role="alert"
-          style="--Paper-shadow: none;"
-        >
-          <div
-            class="MuiAlert-icon css-vab54s-MuiAlert-icon"
-          >
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1ckov0h-MuiSvgIcon-root"
-              data-testid="ReportProblemOutlinedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
-              />
-            </svg>
-          </div>
-          <div
-            class="MuiAlert-message css-zioonp-MuiAlert-message"
-          >
-            <p
-              class="MuiTypography-root MuiTypography-body2 css-7mxp11-MuiTypography-root"
-            >
-              Shared profile detected — 0 fields differ
-            </p>
-          </div>
-          <div
-            class="MuiAlert-action css-rgppqo-MuiAlert-action"
-          >
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeSmall MuiButton-colorInherit css-1fnilek-MuiButtonBase-root-MuiButton-root"
-              tabindex="0"
-              type="button"
-            >
-              Keep mine
-            </button>
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-sizeSmall MuiButton-colorPrimary css-ir2doi-MuiButtonBase-root-MuiButton-root"
-              tabindex="0"
-              type="button"
-            >
-              Load
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
     class="MuiFormControl-root css-1hr5jum-MuiFormControl-root"
   >
     <div
@@ -761,8 +639,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_h_"
-          id="_r_h_-label"
+          for="_r_f_"
+          id="_r_f_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -793,7 +671,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_h_"
+            id="_r_f_"
             placeholder="To be deposited at bank"
             type="number"
             value="100000"
@@ -839,8 +717,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_k_"
-          id="_r_k_-label"
+          for="_r_i_"
+          id="_r_i_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -871,7 +749,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_k_"
+            id="_r_i_"
             placeholder="Current age"
             type="number"
             value="10"
@@ -917,8 +795,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_n_"
-          id="_r_n_-label"
+          for="_r_l_"
+          id="_r_l_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -949,7 +827,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_n_"
+            id="_r_l_"
             placeholder="Credited to bank monthly"
             type="number"
             value="3000"
@@ -995,8 +873,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_q_"
-          id="_r_q_-label"
+          for="_r_o_"
+          id="_r_o_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -1014,7 +892,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_q_"
+            id="_r_o_"
             placeholder="Pay to bank yearly"
             type="number"
             value=""
@@ -1047,8 +925,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_r_"
-          id="_r_r_-label"
+          for="_r_p_"
+          id="_r_p_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -1066,7 +944,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_r_"
+            id="_r_p_"
             placeholder="Pay to bank yearly"
             type="number"
             value=""
@@ -1099,8 +977,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_s_"
-          id="_r_s_-label"
+          for="_r_q_"
+          id="_r_q_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -1131,7 +1009,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_s_"
+            id="_r_q_"
             placeholder="On eligible cards monthly"
             type="number"
             value="1000"
@@ -1177,8 +1055,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_v_"
-          id="_r_v_-label"
+          for="_r_t_"
+          id="_r_t_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -1196,7 +1074,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_v_"
+            id="_r_t_"
             placeholder="No. of GIRO Transactions"
             type="number"
             value=""
@@ -1229,8 +1107,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_10_"
-          id="_r_10_-label"
+          for="_r_u_"
+          id="_r_u_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -1261,7 +1139,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_10_"
+            id="_r_u_"
             placeholder="Balance increase monthly"
             type="number"
             value="500"
@@ -1307,8 +1185,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_13_"
-          id="_r_13_-label"
+          for="_r_11_"
+          id="_r_11_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -1326,7 +1204,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_13_"
+            id="_r_11_"
             placeholder="Monthly loan payment"
             type="number"
             value=""
@@ -1359,8 +1237,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_14_"
-          id="_r_14_-label"
+          for="_r_12_"
+          id="_r_12_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -1378,7 +1256,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_14_"
+            id="_r_12_"
             placeholder="Additional 1 time loan"
             type="number"
             value=""

--- a/src/Components/__snapshots__/Inputs.test.tsx.snap
+++ b/src/Components/__snapshots__/Inputs.test.tsx.snap
@@ -622,6 +622,9 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
       </span>
     </div>
   </div>
+  <div
+    class="MuiBox-root css-1tdrj8w"
+  />
 </DocumentFragment>
 `;
 
@@ -1377,5 +1380,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
       </span>
     </div>
   </div>
+  <div
+    class="MuiBox-root css-1tdrj8w"
+  />
 </DocumentFragment>
 `;

--- a/src/Components/__snapshots__/Inputs.test.tsx.snap
+++ b/src/Components/__snapshots__/Inputs.test.tsx.snap
@@ -569,6 +569,28 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
     class="MuiBox-root css-1423sdf"
   >
     <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary css-1y5jhkt-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiButton-icon MuiButton-startIcon css-1sh91j5-MuiButton-startIcon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          data-testid="ShareOutlinedIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92s2.92-1.31 2.92-2.92-1.31-2.92-2.92-2.92M18 4c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1M6 13c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1m12 7.02c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1"
+          />
+        </svg>
+      </span>
+      Share
+    </button>
+    <button
       class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary css-13rq0se-MuiButtonBase-root-MuiButton-root"
       tabindex="0"
       type="button"
@@ -617,8 +639,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_c_"
-          id="_r_c_-label"
+          for="_r_d_"
+          id="_r_d_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -649,7 +671,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_c_"
+            id="_r_d_"
             placeholder="To be deposited at bank"
             type="number"
             value="100000"
@@ -695,8 +717,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_f_"
-          id="_r_f_-label"
+          for="_r_g_"
+          id="_r_g_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -727,7 +749,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_f_"
+            id="_r_g_"
             placeholder="Current age"
             type="number"
             value="10"
@@ -773,8 +795,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_i_"
-          id="_r_i_-label"
+          for="_r_j_"
+          id="_r_j_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -805,7 +827,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_i_"
+            id="_r_j_"
             placeholder="Credited to bank monthly"
             type="number"
             value="3000"
@@ -851,8 +873,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_l_"
-          id="_r_l_-label"
+          for="_r_m_"
+          id="_r_m_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -870,7 +892,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_l_"
+            id="_r_m_"
             placeholder="Pay to bank yearly"
             type="number"
             value=""
@@ -903,8 +925,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_m_"
-          id="_r_m_-label"
+          for="_r_n_"
+          id="_r_n_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -922,7 +944,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_m_"
+            id="_r_n_"
             placeholder="Pay to bank yearly"
             type="number"
             value=""
@@ -955,8 +977,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_n_"
-          id="_r_n_-label"
+          for="_r_o_"
+          id="_r_o_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -987,7 +1009,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_n_"
+            id="_r_o_"
             placeholder="On eligible cards monthly"
             type="number"
             value="1000"
@@ -1033,8 +1055,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_q_"
-          id="_r_q_-label"
+          for="_r_r_"
+          id="_r_r_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -1052,7 +1074,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_q_"
+            id="_r_r_"
             placeholder="No. of GIRO Transactions"
             type="number"
             value=""
@@ -1085,8 +1107,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_r_"
-          id="_r_r_-label"
+          for="_r_s_"
+          id="_r_s_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -1117,7 +1139,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_r_"
+            id="_r_s_"
             placeholder="Balance increase monthly"
             type="number"
             value="500"
@@ -1163,8 +1185,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_u_"
-          id="_r_u_-label"
+          for="_r_v_"
+          id="_r_v_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -1182,7 +1204,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_u_"
+            id="_r_v_"
             placeholder="Monthly loan payment"
             type="number"
             value=""
@@ -1215,8 +1237,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_v_"
-          id="_r_v_-label"
+          for="_r_10_"
+          id="_r_10_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -1234,7 +1256,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_v_"
+            id="_r_10_"
             placeholder="Additional 1 time loan"
             type="number"
             value=""
@@ -1301,6 +1323,28 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
   <div
     class="MuiBox-root css-1423sdf"
   >
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary css-1y5jhkt-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiButton-icon MuiButton-startIcon css-1sh91j5-MuiButton-startIcon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          data-testid="ShareOutlinedIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92s2.92-1.31 2.92-2.92-1.31-2.92-2.92-2.92M18 4c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1M6 13c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1m12 7.02c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1"
+          />
+        </svg>
+      </span>
+      Share
+    </button>
     <button
       class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary css-13rq0se-MuiButtonBase-root-MuiButton-root"
       tabindex="0"

--- a/src/Components/__snapshots__/Inputs.test.tsx.snap
+++ b/src/Components/__snapshots__/Inputs.test.tsx.snap
@@ -14,8 +14,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_0_"
-          id="_r_0_-label"
+          for="_r_1_"
+          id="_r_1_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -33,7 +33,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_0_"
+            id="_r_1_"
             placeholder="To be deposited at bank"
             type="number"
             value=""
@@ -66,8 +66,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_1_"
-          id="_r_1_-label"
+          for="_r_2_"
+          id="_r_2_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -85,7 +85,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_1_"
+            id="_r_2_"
             placeholder="Current age"
             type="number"
             value=""
@@ -118,8 +118,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_2_"
-          id="_r_2_-label"
+          for="_r_3_"
+          id="_r_3_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -137,7 +137,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_2_"
+            id="_r_3_"
             placeholder="Credited to bank monthly"
             type="number"
             value=""
@@ -170,8 +170,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_3_"
-          id="_r_3_-label"
+          for="_r_4_"
+          id="_r_4_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -189,7 +189,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_3_"
+            id="_r_4_"
             placeholder="Pay to bank yearly"
             type="number"
             value=""
@@ -222,8 +222,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_4_"
-          id="_r_4_-label"
+          for="_r_5_"
+          id="_r_5_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -241,7 +241,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_4_"
+            id="_r_5_"
             placeholder="Pay to bank yearly"
             type="number"
             value=""
@@ -274,8 +274,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_5_"
-          id="_r_5_-label"
+          for="_r_6_"
+          id="_r_6_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -293,7 +293,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_5_"
+            id="_r_6_"
             placeholder="On eligible cards monthly"
             type="number"
             value=""
@@ -326,8 +326,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_6_"
-          id="_r_6_-label"
+          for="_r_7_"
+          id="_r_7_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -345,7 +345,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_6_"
+            id="_r_7_"
             placeholder="No. of GIRO Transactions"
             type="number"
             value=""
@@ -378,8 +378,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_7_"
-          id="_r_7_-label"
+          for="_r_8_"
+          id="_r_8_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -397,7 +397,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_7_"
+            id="_r_8_"
             placeholder="Balance increase monthly"
             type="number"
             value=""
@@ -430,8 +430,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_8_"
-          id="_r_8_-label"
+          for="_r_9_"
+          id="_r_9_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -449,7 +449,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_8_"
+            id="_r_9_"
             placeholder="Monthly loan payment"
             type="number"
             value=""
@@ -482,8 +482,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_9_"
-          id="_r_9_-label"
+          for="_r_a_"
+          id="_r_a_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -501,7 +501,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_9_"
+            id="_r_a_"
             placeholder="Additional 1 time loan"
             type="number"
             value=""
@@ -639,8 +639,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_d_"
-          id="_r_d_-label"
+          for="_r_h_"
+          id="_r_h_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -671,7 +671,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_d_"
+            id="_r_h_"
             placeholder="To be deposited at bank"
             type="number"
             value="100000"
@@ -717,8 +717,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_g_"
-          id="_r_g_-label"
+          for="_r_k_"
+          id="_r_k_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -749,7 +749,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_g_"
+            id="_r_k_"
             placeholder="Current age"
             type="number"
             value="10"
@@ -795,8 +795,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_j_"
-          id="_r_j_-label"
+          for="_r_n_"
+          id="_r_n_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -827,7 +827,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_j_"
+            id="_r_n_"
             placeholder="Credited to bank monthly"
             type="number"
             value="3000"
@@ -873,8 +873,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_m_"
-          id="_r_m_-label"
+          for="_r_q_"
+          id="_r_q_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -892,7 +892,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_m_"
+            id="_r_q_"
             placeholder="Pay to bank yearly"
             type="number"
             value=""
@@ -925,8 +925,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_n_"
-          id="_r_n_-label"
+          for="_r_r_"
+          id="_r_r_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -944,7 +944,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_n_"
+            id="_r_r_"
             placeholder="Pay to bank yearly"
             type="number"
             value=""
@@ -977,8 +977,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_o_"
-          id="_r_o_-label"
+          for="_r_s_"
+          id="_r_s_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -1009,7 +1009,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_o_"
+            id="_r_s_"
             placeholder="On eligible cards monthly"
             type="number"
             value="1000"
@@ -1055,8 +1055,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_r_"
-          id="_r_r_-label"
+          for="_r_v_"
+          id="_r_v_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -1074,7 +1074,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_r_"
+            id="_r_v_"
             placeholder="No. of GIRO Transactions"
             type="number"
             value=""
@@ -1107,8 +1107,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for="_r_s_"
-          id="_r_s_-label"
+          for="_r_10_"
+          id="_r_10_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -1139,7 +1139,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_s_"
+            id="_r_10_"
             placeholder="Balance increase monthly"
             type="number"
             value="500"
@@ -1185,8 +1185,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_v_"
-          id="_r_v_-label"
+          for="_r_13_"
+          id="_r_13_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -1204,7 +1204,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_v_"
+            id="_r_13_"
             placeholder="Monthly loan payment"
             type="number"
             value=""
@@ -1237,8 +1237,8 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_10_"
-          id="_r_10_-label"
+          for="_r_14_"
+          id="_r_14_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -1256,7 +1256,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_10_"
+            id="_r_14_"
             placeholder="Additional 1 time loan"
             type="number"
             value=""

--- a/src/Components/__snapshots__/Inputs.test.tsx.snap
+++ b/src/Components/__snapshots__/Inputs.test.tsx.snap
@@ -3,6 +3,63 @@
 exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
 <DocumentFragment>
   <div
+    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-cwrbtg-MuiCollapse-root"
+    style="min-height: 0px;"
+  >
+    <div
+      class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
+    >
+      <div
+        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standard css-1wzkehk-MuiPaper-root-MuiAlert-root"
+          role="alert"
+          style="--Paper-shadow: none;"
+        >
+          <div
+            class="MuiAlert-icon css-vab54s-MuiAlert-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1ckov0h-MuiSvgIcon-root"
+              data-testid="ReportProblemOutlinedIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiAlert-message css-zioonp-MuiAlert-message"
+          >
+            Shared profile detected — load it?
+          </div>
+          <div
+            class="MuiAlert-action css-rgppqo-MuiAlert-action"
+          >
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeSmall MuiButton-colorInherit css-1fnilek-MuiButtonBase-root-MuiButton-root"
+              tabindex="0"
+              type="button"
+            >
+              Keep mine
+            </button>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-sizeSmall MuiButton-colorPrimary css-ir2doi-MuiButtonBase-root-MuiButton-root"
+              tabindex="0"
+              type="button"
+            >
+              Load
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
     class="MuiFormControl-root css-1hr5jum-MuiFormControl-root"
   >
     <div
@@ -14,8 +71,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_1_"
-          id="_r_1_-label"
+          for="_r_2_"
+          id="_r_2_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -33,7 +90,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_1_"
+            id="_r_2_"
             placeholder="To be deposited at bank"
             type="number"
             value=""
@@ -66,8 +123,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_2_"
-          id="_r_2_-label"
+          for="_r_3_"
+          id="_r_3_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -85,7 +142,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_2_"
+            id="_r_3_"
             placeholder="Current age"
             type="number"
             value=""
@@ -118,8 +175,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_3_"
-          id="_r_3_-label"
+          for="_r_4_"
+          id="_r_4_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -137,7 +194,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_3_"
+            id="_r_4_"
             placeholder="Credited to bank monthly"
             type="number"
             value=""
@@ -170,8 +227,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_4_"
-          id="_r_4_-label"
+          for="_r_5_"
+          id="_r_5_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -189,7 +246,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_4_"
+            id="_r_5_"
             placeholder="Pay to bank yearly"
             type="number"
             value=""
@@ -222,8 +279,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_5_"
-          id="_r_5_-label"
+          for="_r_6_"
+          id="_r_6_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -241,7 +298,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_5_"
+            id="_r_6_"
             placeholder="Pay to bank yearly"
             type="number"
             value=""
@@ -274,8 +331,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_6_"
-          id="_r_6_-label"
+          for="_r_7_"
+          id="_r_7_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -293,7 +350,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_6_"
+            id="_r_7_"
             placeholder="On eligible cards monthly"
             type="number"
             value=""
@@ -326,8 +383,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_7_"
-          id="_r_7_-label"
+          for="_r_8_"
+          id="_r_8_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -345,7 +402,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_7_"
+            id="_r_8_"
             placeholder="No. of GIRO Transactions"
             type="number"
             value=""
@@ -378,8 +435,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_8_"
-          id="_r_8_-label"
+          for="_r_9_"
+          id="_r_9_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -397,7 +454,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_8_"
+            id="_r_9_"
             placeholder="Balance increase monthly"
             type="number"
             value=""
@@ -430,8 +487,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_9_"
-          id="_r_9_-label"
+          for="_r_a_"
+          id="_r_a_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -449,7 +506,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_9_"
+            id="_r_a_"
             placeholder="Monthly loan payment"
             type="number"
             value=""
@@ -482,8 +539,8 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-19qnlrw-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="false"
-          for="_r_a_"
-          id="_r_a_-label"
+          for="_r_b_"
+          id="_r_b_-label"
         >
           <div
             style="display: flex; flex-direction: row;"
@@ -501,7 +558,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <input
             aria-invalid="false"
             class="MuiInputBase-input MuiOutlinedInput-input css-16wblaj-MuiInputBase-input-MuiOutlinedInput-input"
-            id="_r_a_"
+            id="_r_b_"
             placeholder="Additional 1 time loan"
             type="number"
             value=""
@@ -627,6 +684,63 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
 
 exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
 <DocumentFragment>
+  <div
+    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-cwrbtg-MuiCollapse-root"
+    style="min-height: 0px;"
+  >
+    <div
+      class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
+    >
+      <div
+        class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standard css-1wzkehk-MuiPaper-root-MuiAlert-root"
+          role="alert"
+          style="--Paper-shadow: none;"
+        >
+          <div
+            class="MuiAlert-icon css-vab54s-MuiAlert-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1ckov0h-MuiSvgIcon-root"
+              data-testid="ReportProblemOutlinedIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiAlert-message css-zioonp-MuiAlert-message"
+          >
+            Shared profile detected — load it?
+          </div>
+          <div
+            class="MuiAlert-action css-rgppqo-MuiAlert-action"
+          >
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeSmall MuiButton-colorInherit css-1fnilek-MuiButtonBase-root-MuiButton-root"
+              tabindex="0"
+              type="button"
+            >
+              Keep mine
+            </button>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-sizeSmall MuiButton-colorPrimary css-ir2doi-MuiButtonBase-root-MuiButton-root"
+              tabindex="0"
+              type="button"
+            >
+              Load
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
   <div
     class="MuiFormControl-root css-1hr5jum-MuiFormControl-root"
   >

--- a/src/Components/__snapshots__/Inputs.test.tsx.snap
+++ b/src/Components/__snapshots__/Inputs.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
         class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
       >
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standard css-1wzkehk-MuiPaper-root-MuiAlert-root"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standard css-btxnfn-MuiPaper-root-MuiAlert-root"
           role="alert"
           style="--Paper-shadow: none;"
         >
@@ -35,7 +35,11 @@ exports[`Form Inputs > should match snapshot if profile is empty 1`] = `
           <div
             class="MuiAlert-message css-zioonp-MuiAlert-message"
           >
-            Shared profile detected — load it?
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-7mxp11-MuiTypography-root"
+            >
+              Shared profile detected — 0 fields differ
+            </p>
           </div>
           <div
             class="MuiAlert-action css-rgppqo-MuiAlert-action"
@@ -695,7 +699,7 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
         class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
       >
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standard css-1wzkehk-MuiPaper-root-MuiAlert-root"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standard css-btxnfn-MuiPaper-root-MuiAlert-root"
           role="alert"
           style="--Paper-shadow: none;"
         >
@@ -717,7 +721,11 @@ exports[`Form Inputs > should match snapshot if profile is not empty 1`] = `
           <div
             class="MuiAlert-message css-zioonp-MuiAlert-message"
           >
-            Shared profile detected — load it?
+            <p
+              class="MuiTypography-root MuiTypography-body2 css-7mxp11-MuiTypography-root"
+            >
+              Shared profile detected — 0 fields differ
+            </p>
           </div>
           <div
             class="MuiAlert-action css-rgppqo-MuiAlert-action"

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -11,12 +11,21 @@ import type Profile from "./types/profile";
 interface LayoutProps {
   currProfile: Profile;
   setCurrProfile: (p: Profile) => void;
+  pendingUrlProfile: Profile | null;
+  onAcceptShared: () => void;
+  onRejectShared: () => void;
 }
 
 /**
  * Shared layout: Header, then page content via <Outlet>, then Footer.
  */
-export const Layout = ({ currProfile, setCurrProfile }: LayoutProps) => (
+export const Layout = ({
+  currProfile,
+  setCurrProfile,
+  pendingUrlProfile,
+  onAcceptShared,
+  onRejectShared,
+}: LayoutProps) => (
   <ThemeProvider theme={theme}>
     <GlobalStyles
       styles={{
@@ -34,7 +43,15 @@ export const Layout = ({ currProfile, setCurrProfile }: LayoutProps) => (
     <Box component="main" sx={{ marginTop: "20px", paddingBottom: "20px" }}>
       <Container>
         <ErrorBoundary>
-          <Outlet context={{ currProfile, setCurrProfile }} />
+          <Outlet
+            context={{
+              currProfile,
+              setCurrProfile,
+              pendingUrlProfile,
+              onAcceptShared,
+              onRejectShared,
+            }}
+          />
         </ErrorBoundary>
       </Container>
     </Box>
@@ -55,10 +72,17 @@ export const WithInputs = () => (
 
 /** Internal: reads profile state from Outlet context and renders FormInputs */
 const FormInputsWrapper = () => {
-  const { currProfile, setCurrProfile } = useOutletContext<LayoutProps>();
+  const { currProfile, setCurrProfile, pendingUrlProfile, onAcceptShared, onRejectShared } =
+    useOutletContext<LayoutProps>();
   return (
     <ErrorBoundary>
-      <FormInputs currProfile={currProfile} setCurrProfile={setCurrProfile} />
+      <FormInputs
+        currProfile={currProfile}
+        setCurrProfile={setCurrProfile}
+        pendingUrlProfile={pendingUrlProfile}
+        onAcceptShared={onAcceptShared}
+        onRejectShared={onRejectShared}
+      />
     </ErrorBoundary>
   );
 };

--- a/src/__snapshots__/App.test.tsx.snap
+++ b/src/__snapshots__/App.test.tsx.snap
@@ -112,6 +112,63 @@ exports[`App > should render correctly 1`] = `
       class="MuiContainer-root MuiContainer-maxWidthLg css-5c1adp-MuiContainer-root"
     >
       <div
+        class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-cwrbtg-MuiCollapse-root"
+        style="min-height: 0px;"
+      >
+        <div
+          class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
+        >
+          <div
+            class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standard css-1sapdxe-MuiPaper-root-MuiAlert-root"
+              role="alert"
+              style="--Paper-shadow: none; --Paper-overlay: linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 0));"
+            >
+              <div
+                class="MuiAlert-icon css-vab54s-MuiAlert-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1ckov0h-MuiSvgIcon-root"
+                  data-testid="ReportProblemOutlinedIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+                  />
+                </svg>
+              </div>
+              <div
+                class="MuiAlert-message css-zioonp-MuiAlert-message"
+              >
+                Shared profile detected — load it?
+              </div>
+              <div
+                class="MuiAlert-action css-rgppqo-MuiAlert-action"
+              >
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeSmall MuiButton-colorInherit css-1x7rj9k-MuiButtonBase-root-MuiButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  Keep mine
+                </button>
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-sizeSmall MuiButton-colorPrimary css-122qsav-MuiButtonBase-root-MuiButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  Load
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
         class="MuiFormControl-root css-1hr5jum-MuiFormControl-root"
       >
         <div
@@ -123,8 +180,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_4_"
-              id="_r_4_-label"
+              for="_r_5_"
+              id="_r_5_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -142,7 +199,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_4_"
+                id="_r_5_"
                 placeholder="To be deposited at bank"
                 type="number"
                 value=""
@@ -175,8 +232,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_5_"
-              id="_r_5_-label"
+              for="_r_6_"
+              id="_r_6_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -194,7 +251,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_5_"
+                id="_r_6_"
                 placeholder="Current age"
                 type="number"
                 value=""
@@ -227,8 +284,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_6_"
-              id="_r_6_-label"
+              for="_r_7_"
+              id="_r_7_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -246,7 +303,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_6_"
+                id="_r_7_"
                 placeholder="Credited to bank monthly"
                 type="number"
                 value=""
@@ -279,8 +336,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_7_"
-              id="_r_7_-label"
+              for="_r_8_"
+              id="_r_8_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -298,7 +355,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_7_"
+                id="_r_8_"
                 placeholder="Pay to bank yearly"
                 type="number"
                 value=""
@@ -331,8 +388,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_8_"
-              id="_r_8_-label"
+              for="_r_9_"
+              id="_r_9_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -350,7 +407,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_8_"
+                id="_r_9_"
                 placeholder="Pay to bank yearly"
                 type="number"
                 value=""
@@ -383,8 +440,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_9_"
-              id="_r_9_-label"
+              for="_r_a_"
+              id="_r_a_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -402,7 +459,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_9_"
+                id="_r_a_"
                 placeholder="On eligible cards monthly"
                 type="number"
                 value=""
@@ -435,8 +492,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_a_"
-              id="_r_a_-label"
+              for="_r_b_"
+              id="_r_b_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -454,7 +511,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_a_"
+                id="_r_b_"
                 placeholder="No. of GIRO Transactions"
                 type="number"
                 value=""
@@ -487,8 +544,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_b_"
-              id="_r_b_-label"
+              for="_r_c_"
+              id="_r_c_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -506,7 +563,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_b_"
+                id="_r_c_"
                 placeholder="Balance increase monthly"
                 type="number"
                 value=""
@@ -539,8 +596,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_c_"
-              id="_r_c_-label"
+              for="_r_d_"
+              id="_r_d_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -558,7 +615,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_c_"
+                id="_r_d_"
                 placeholder="Monthly loan payment"
                 type="number"
                 value=""
@@ -591,8 +648,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_d_"
-              id="_r_d_-label"
+              for="_r_e_"
+              id="_r_e_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -610,7 +667,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_d_"
+                id="_r_e_"
                 placeholder="Additional 1 time loan"
                 type="number"
                 value=""
@@ -2575,20 +2632,20 @@ exports[`App > should render correctly 1`] = `
                   tabindex="0"
                 >
                   <div
-                    id="voiceover-_r_2a_-1"
+                    id="voiceover-_r_2b_-1"
                     style="display: none;"
                   />
                   <div
-                    id="voiceover-_r_2a_-2"
+                    id="voiceover-_r_2b_-2"
                     style="display: none;"
                   />
                   <div
-                    aria-labelledby="voiceover-_r_2a_-1"
+                    aria-labelledby="voiceover-_r_2b_-1"
                     role="img"
                     style="width: 100%; height: 100%; outline: none;"
                   />
                   <div
-                    aria-labelledby="voiceover-_r_2a_-2"
+                    aria-labelledby="voiceover-_r_2b_-2"
                     role="img"
                     style="width: 100%; height: 100%; outline: none;"
                   />
@@ -2680,7 +2737,7 @@ exports[`App > should render correctly 1`] = `
                     />
                   </g>
                   <g
-                    clip-path="url(#_r_29_-clip-path)"
+                    clip-path="url(#_r_2a_-clip-path)"
                   >
                     <g
                       class="MuiLineChart-areaPlot css-94vonx-MuiAreaPlot-root"
@@ -2689,7 +2746,7 @@ exports[`App > should render correctly 1`] = `
                       class="MuiLineChart-linePlot css-1ygpbzp-MuiLinePlot-root"
                     >
                       <clippath
-                        id="_r_2a_-uob-one-account-line-clip"
+                        id="_r_2b_-uob-one-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2700,7 +2757,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2a_-uob-one-account-line-clip)"
+                        clip-path="url(#_r_2b_-uob-one-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2716,7 +2773,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2a_-ocbc-360-account-line-clip"
+                        id="_r_2b_-ocbc-360-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2727,7 +2784,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2a_-ocbc-360-account-line-clip)"
+                        clip-path="url(#_r_2b_-ocbc-360-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2743,7 +2800,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2a_-mari-savings-account-line-clip"
+                        id="_r_2b_-mari-savings-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2754,7 +2811,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2a_-mari-savings-account-line-clip)"
+                        clip-path="url(#_r_2b_-mari-savings-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2770,7 +2827,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2a_-standard-chartered-bonus-saver-line-clip"
+                        id="_r_2b_-standard-chartered-bonus-saver-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2781,7 +2838,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2a_-standard-chartered-bonus-saver-line-clip)"
+                        clip-path="url(#_r_2b_-standard-chartered-bonus-saver-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2797,7 +2854,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2a_-trust-bank-signature-line-clip"
+                        id="_r_2b_-trust-bank-signature-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2808,7 +2865,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2a_-trust-bank-signature-line-clip)"
+                        clip-path="url(#_r_2b_-trust-bank-signature-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2824,7 +2881,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2a_-trust-bank-zen-line-clip"
+                        id="_r_2b_-trust-bank-zen-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2835,7 +2892,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2a_-trust-bank-zen-line-clip)"
+                        clip-path="url(#_r_2b_-trust-bank-zen-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2851,7 +2908,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2a_-dbs-multiplier-account-line-clip"
+                        id="_r_2b_-dbs-multiplier-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2862,7 +2919,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2a_-dbs-multiplier-account-line-clip)"
+                        clip-path="url(#_r_2b_-dbs-multiplier-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2878,7 +2935,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2a_-gxs-savings-account-line-clip"
+                        id="_r_2b_-gxs-savings-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2889,7 +2946,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2a_-gxs-savings-account-line-clip)"
+                        clip-path="url(#_r_2b_-gxs-savings-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2905,7 +2962,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2a_-chocolate-finance-line-clip"
+                        id="_r_2b_-chocolate-finance-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2916,7 +2973,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2a_-chocolate-finance-line-clip)"
+                        clip-path="url(#_r_2b_-chocolate-finance-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2932,7 +2989,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2a_-boc-supersaver-line-clip"
+                        id="_r_2b_-boc-supersaver-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2943,7 +3000,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2a_-boc-supersaver-line-clip)"
+                        clip-path="url(#_r_2b_-boc-supersaver-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2959,7 +3016,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2a_-maybank-saveup-line-clip"
+                        id="_r_2b_-maybank-saveup-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2970,7 +3027,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2a_-maybank-saveup-line-clip)"
+                        clip-path="url(#_r_2b_-maybank-saveup-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2986,7 +3043,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2a_-maybank-isavvy-line-clip"
+                        id="_r_2b_-maybank-isavvy-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2997,7 +3054,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2a_-maybank-isavvy-line-clip)"
+                        clip-path="url(#_r_2b_-maybank-isavvy-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -3013,7 +3070,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2a_-maybank-isavvy-plus-line-clip"
+                        id="_r_2b_-maybank-isavvy-plus-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -3024,7 +3081,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2a_-maybank-isavvy-plus-line-clip)"
+                        clip-path="url(#_r_2b_-maybank-isavvy-plus-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -3040,7 +3097,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2a_-citi-wealth-first-account-line-clip"
+                        id="_r_2b_-citi-wealth-first-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -3051,7 +3108,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2a_-citi-wealth-first-account-line-clip)"
+                        clip-path="url(#_r_2b_-citi-wealth-first-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -3412,65 +3469,65 @@ exports[`App > should render correctly 1`] = `
                       class="MuiLineChart-markPlot css-1xks5uz-MuiMarkPlot-root"
                     >
                       <g
-                        clip-path="url(#_r_2a_-uob-one-account-line-clip)"
+                        clip-path="url(#_r_2b_-uob-one-account-line-clip)"
                         data-series="uob-one-account"
                       />
                       <g
-                        clip-path="url(#_r_2a_-ocbc-360-account-line-clip)"
+                        clip-path="url(#_r_2b_-ocbc-360-account-line-clip)"
                         data-series="ocbc-360-account"
                       />
                       <g
-                        clip-path="url(#_r_2a_-mari-savings-account-line-clip)"
+                        clip-path="url(#_r_2b_-mari-savings-account-line-clip)"
                         data-series="mari-savings-account"
                       />
                       <g
-                        clip-path="url(#_r_2a_-standard-chartered-bonus-saver-line-clip)"
+                        clip-path="url(#_r_2b_-standard-chartered-bonus-saver-line-clip)"
                         data-series="standard-chartered-bonus-saver"
                       />
                       <g
-                        clip-path="url(#_r_2a_-trust-bank-signature-line-clip)"
+                        clip-path="url(#_r_2b_-trust-bank-signature-line-clip)"
                         data-series="trust-bank-signature"
                       />
                       <g
-                        clip-path="url(#_r_2a_-trust-bank-zen-line-clip)"
+                        clip-path="url(#_r_2b_-trust-bank-zen-line-clip)"
                         data-series="trust-bank-zen"
                       />
                       <g
-                        clip-path="url(#_r_2a_-dbs-multiplier-account-line-clip)"
+                        clip-path="url(#_r_2b_-dbs-multiplier-account-line-clip)"
                         data-series="dbs-multiplier-account"
                       />
                       <g
-                        clip-path="url(#_r_2a_-gxs-savings-account-line-clip)"
+                        clip-path="url(#_r_2b_-gxs-savings-account-line-clip)"
                         data-series="gxs-savings-account"
                       />
                       <g
-                        clip-path="url(#_r_2a_-chocolate-finance-line-clip)"
+                        clip-path="url(#_r_2b_-chocolate-finance-line-clip)"
                         data-series="chocolate-finance"
                       />
                       <g
-                        clip-path="url(#_r_2a_-boc-supersaver-line-clip)"
+                        clip-path="url(#_r_2b_-boc-supersaver-line-clip)"
                         data-series="boc-supersaver"
                       />
                       <g
-                        clip-path="url(#_r_2a_-maybank-saveup-line-clip)"
+                        clip-path="url(#_r_2b_-maybank-saveup-line-clip)"
                         data-series="maybank-saveup"
                       />
                       <g
-                        clip-path="url(#_r_2a_-maybank-isavvy-line-clip)"
+                        clip-path="url(#_r_2b_-maybank-isavvy-line-clip)"
                         data-series="maybank-isavvy"
                       />
                       <g
-                        clip-path="url(#_r_2a_-maybank-isavvy-plus-line-clip)"
+                        clip-path="url(#_r_2b_-maybank-isavvy-plus-line-clip)"
                         data-series="maybank-isavvy-plus"
                       />
                       <g
-                        clip-path="url(#_r_2a_-citi-wealth-first-account-line-clip)"
+                        clip-path="url(#_r_2b_-citi-wealth-first-account-line-clip)"
                         data-series="citi-wealth-first-account"
                       />
                     </g>
                   </g>
                   <clippath
-                    id="_r_29_-clip-path"
+                    id="_r_2a_-clip-path"
                   >
                     <rect
                       height="415"

--- a/src/__snapshots__/App.test.tsx.snap
+++ b/src/__snapshots__/App.test.tsx.snap
@@ -123,8 +123,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_3_"
-              id="_r_3_-label"
+              for="_r_4_"
+              id="_r_4_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -142,7 +142,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_3_"
+                id="_r_4_"
                 placeholder="To be deposited at bank"
                 type="number"
                 value=""
@@ -175,8 +175,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_4_"
-              id="_r_4_-label"
+              for="_r_5_"
+              id="_r_5_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -194,7 +194,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_4_"
+                id="_r_5_"
                 placeholder="Current age"
                 type="number"
                 value=""
@@ -227,8 +227,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_5_"
-              id="_r_5_-label"
+              for="_r_6_"
+              id="_r_6_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -246,7 +246,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_5_"
+                id="_r_6_"
                 placeholder="Credited to bank monthly"
                 type="number"
                 value=""
@@ -279,8 +279,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_6_"
-              id="_r_6_-label"
+              for="_r_7_"
+              id="_r_7_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -298,7 +298,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_6_"
+                id="_r_7_"
                 placeholder="Pay to bank yearly"
                 type="number"
                 value=""
@@ -331,8 +331,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_7_"
-              id="_r_7_-label"
+              for="_r_8_"
+              id="_r_8_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -350,7 +350,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_7_"
+                id="_r_8_"
                 placeholder="Pay to bank yearly"
                 type="number"
                 value=""
@@ -383,8 +383,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_8_"
-              id="_r_8_-label"
+              for="_r_9_"
+              id="_r_9_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -402,7 +402,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_8_"
+                id="_r_9_"
                 placeholder="On eligible cards monthly"
                 type="number"
                 value=""
@@ -435,8 +435,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_9_"
-              id="_r_9_-label"
+              for="_r_a_"
+              id="_r_a_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -454,7 +454,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_9_"
+                id="_r_a_"
                 placeholder="No. of GIRO Transactions"
                 type="number"
                 value=""
@@ -487,8 +487,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_a_"
-              id="_r_a_-label"
+              for="_r_b_"
+              id="_r_b_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -506,7 +506,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_a_"
+                id="_r_b_"
                 placeholder="Balance increase monthly"
                 type="number"
                 value=""
@@ -539,8 +539,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_b_"
-              id="_r_b_-label"
+              for="_r_c_"
+              id="_r_c_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -558,7 +558,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_b_"
+                id="_r_c_"
                 placeholder="Monthly loan payment"
                 type="number"
                 value=""
@@ -591,8 +591,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_c_"
-              id="_r_c_-label"
+              for="_r_d_"
+              id="_r_d_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -610,7 +610,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_c_"
+                id="_r_d_"
                 placeholder="Additional 1 time loan"
                 type="number"
                 value=""
@@ -2575,20 +2575,20 @@ exports[`App > should render correctly 1`] = `
                   tabindex="0"
                 >
                   <div
-                    id="voiceover-_r_29_-1"
+                    id="voiceover-_r_2a_-1"
                     style="display: none;"
                   />
                   <div
-                    id="voiceover-_r_29_-2"
+                    id="voiceover-_r_2a_-2"
                     style="display: none;"
                   />
                   <div
-                    aria-labelledby="voiceover-_r_29_-1"
+                    aria-labelledby="voiceover-_r_2a_-1"
                     role="img"
                     style="width: 100%; height: 100%; outline: none;"
                   />
                   <div
-                    aria-labelledby="voiceover-_r_29_-2"
+                    aria-labelledby="voiceover-_r_2a_-2"
                     role="img"
                     style="width: 100%; height: 100%; outline: none;"
                   />
@@ -2680,7 +2680,7 @@ exports[`App > should render correctly 1`] = `
                     />
                   </g>
                   <g
-                    clip-path="url(#_r_28_-clip-path)"
+                    clip-path="url(#_r_29_-clip-path)"
                   >
                     <g
                       class="MuiLineChart-areaPlot css-94vonx-MuiAreaPlot-root"
@@ -2689,7 +2689,7 @@ exports[`App > should render correctly 1`] = `
                       class="MuiLineChart-linePlot css-1ygpbzp-MuiLinePlot-root"
                     >
                       <clippath
-                        id="_r_29_-uob-one-account-line-clip"
+                        id="_r_2a_-uob-one-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2700,7 +2700,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_29_-uob-one-account-line-clip)"
+                        clip-path="url(#_r_2a_-uob-one-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2716,7 +2716,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_29_-ocbc-360-account-line-clip"
+                        id="_r_2a_-ocbc-360-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2727,7 +2727,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_29_-ocbc-360-account-line-clip)"
+                        clip-path="url(#_r_2a_-ocbc-360-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2743,7 +2743,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_29_-mari-savings-account-line-clip"
+                        id="_r_2a_-mari-savings-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2754,7 +2754,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_29_-mari-savings-account-line-clip)"
+                        clip-path="url(#_r_2a_-mari-savings-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2770,7 +2770,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_29_-standard-chartered-bonus-saver-line-clip"
+                        id="_r_2a_-standard-chartered-bonus-saver-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2781,7 +2781,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_29_-standard-chartered-bonus-saver-line-clip)"
+                        clip-path="url(#_r_2a_-standard-chartered-bonus-saver-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2797,7 +2797,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_29_-trust-bank-signature-line-clip"
+                        id="_r_2a_-trust-bank-signature-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2808,7 +2808,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_29_-trust-bank-signature-line-clip)"
+                        clip-path="url(#_r_2a_-trust-bank-signature-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2824,7 +2824,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_29_-trust-bank-zen-line-clip"
+                        id="_r_2a_-trust-bank-zen-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2835,7 +2835,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_29_-trust-bank-zen-line-clip)"
+                        clip-path="url(#_r_2a_-trust-bank-zen-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2851,7 +2851,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_29_-dbs-multiplier-account-line-clip"
+                        id="_r_2a_-dbs-multiplier-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2862,7 +2862,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_29_-dbs-multiplier-account-line-clip)"
+                        clip-path="url(#_r_2a_-dbs-multiplier-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2878,7 +2878,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_29_-gxs-savings-account-line-clip"
+                        id="_r_2a_-gxs-savings-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2889,7 +2889,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_29_-gxs-savings-account-line-clip)"
+                        clip-path="url(#_r_2a_-gxs-savings-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2905,7 +2905,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_29_-chocolate-finance-line-clip"
+                        id="_r_2a_-chocolate-finance-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2916,7 +2916,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_29_-chocolate-finance-line-clip)"
+                        clip-path="url(#_r_2a_-chocolate-finance-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2932,7 +2932,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_29_-boc-supersaver-line-clip"
+                        id="_r_2a_-boc-supersaver-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2943,7 +2943,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_29_-boc-supersaver-line-clip)"
+                        clip-path="url(#_r_2a_-boc-supersaver-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2959,7 +2959,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_29_-maybank-saveup-line-clip"
+                        id="_r_2a_-maybank-saveup-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2970,7 +2970,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_29_-maybank-saveup-line-clip)"
+                        clip-path="url(#_r_2a_-maybank-saveup-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2986,7 +2986,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_29_-maybank-isavvy-line-clip"
+                        id="_r_2a_-maybank-isavvy-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2997,7 +2997,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_29_-maybank-isavvy-line-clip)"
+                        clip-path="url(#_r_2a_-maybank-isavvy-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -3013,7 +3013,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_29_-maybank-isavvy-plus-line-clip"
+                        id="_r_2a_-maybank-isavvy-plus-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -3024,7 +3024,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_29_-maybank-isavvy-plus-line-clip)"
+                        clip-path="url(#_r_2a_-maybank-isavvy-plus-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -3040,7 +3040,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_29_-citi-wealth-first-account-line-clip"
+                        id="_r_2a_-citi-wealth-first-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -3051,7 +3051,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_29_-citi-wealth-first-account-line-clip)"
+                        clip-path="url(#_r_2a_-citi-wealth-first-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -3412,65 +3412,65 @@ exports[`App > should render correctly 1`] = `
                       class="MuiLineChart-markPlot css-1xks5uz-MuiMarkPlot-root"
                     >
                       <g
-                        clip-path="url(#_r_29_-uob-one-account-line-clip)"
+                        clip-path="url(#_r_2a_-uob-one-account-line-clip)"
                         data-series="uob-one-account"
                       />
                       <g
-                        clip-path="url(#_r_29_-ocbc-360-account-line-clip)"
+                        clip-path="url(#_r_2a_-ocbc-360-account-line-clip)"
                         data-series="ocbc-360-account"
                       />
                       <g
-                        clip-path="url(#_r_29_-mari-savings-account-line-clip)"
+                        clip-path="url(#_r_2a_-mari-savings-account-line-clip)"
                         data-series="mari-savings-account"
                       />
                       <g
-                        clip-path="url(#_r_29_-standard-chartered-bonus-saver-line-clip)"
+                        clip-path="url(#_r_2a_-standard-chartered-bonus-saver-line-clip)"
                         data-series="standard-chartered-bonus-saver"
                       />
                       <g
-                        clip-path="url(#_r_29_-trust-bank-signature-line-clip)"
+                        clip-path="url(#_r_2a_-trust-bank-signature-line-clip)"
                         data-series="trust-bank-signature"
                       />
                       <g
-                        clip-path="url(#_r_29_-trust-bank-zen-line-clip)"
+                        clip-path="url(#_r_2a_-trust-bank-zen-line-clip)"
                         data-series="trust-bank-zen"
                       />
                       <g
-                        clip-path="url(#_r_29_-dbs-multiplier-account-line-clip)"
+                        clip-path="url(#_r_2a_-dbs-multiplier-account-line-clip)"
                         data-series="dbs-multiplier-account"
                       />
                       <g
-                        clip-path="url(#_r_29_-gxs-savings-account-line-clip)"
+                        clip-path="url(#_r_2a_-gxs-savings-account-line-clip)"
                         data-series="gxs-savings-account"
                       />
                       <g
-                        clip-path="url(#_r_29_-chocolate-finance-line-clip)"
+                        clip-path="url(#_r_2a_-chocolate-finance-line-clip)"
                         data-series="chocolate-finance"
                       />
                       <g
-                        clip-path="url(#_r_29_-boc-supersaver-line-clip)"
+                        clip-path="url(#_r_2a_-boc-supersaver-line-clip)"
                         data-series="boc-supersaver"
                       />
                       <g
-                        clip-path="url(#_r_29_-maybank-saveup-line-clip)"
+                        clip-path="url(#_r_2a_-maybank-saveup-line-clip)"
                         data-series="maybank-saveup"
                       />
                       <g
-                        clip-path="url(#_r_29_-maybank-isavvy-line-clip)"
+                        clip-path="url(#_r_2a_-maybank-isavvy-line-clip)"
                         data-series="maybank-isavvy"
                       />
                       <g
-                        clip-path="url(#_r_29_-maybank-isavvy-plus-line-clip)"
+                        clip-path="url(#_r_2a_-maybank-isavvy-plus-line-clip)"
                         data-series="maybank-isavvy-plus"
                       />
                       <g
-                        clip-path="url(#_r_29_-citi-wealth-first-account-line-clip)"
+                        clip-path="url(#_r_2a_-citi-wealth-first-account-line-clip)"
                         data-series="citi-wealth-first-account"
                       />
                     </g>
                   </g>
                   <clippath
-                    id="_r_28_-clip-path"
+                    id="_r_29_-clip-path"
                   >
                     <rect
                       height="415"

--- a/src/__snapshots__/App.test.tsx.snap
+++ b/src/__snapshots__/App.test.tsx.snap
@@ -732,6 +732,9 @@ exports[`App > should render correctly 1`] = `
         </div>
       </div>
       <div
+        class="MuiBox-root css-1tdrj8w"
+      />
+      <div
         class="MuiContainer-root MuiContainer-maxWidthLg css-1jqmhqx-MuiContainer-root"
       >
         <section

--- a/src/__snapshots__/App.test.tsx.snap
+++ b/src/__snapshots__/App.test.tsx.snap
@@ -678,6 +678,28 @@ exports[`App > should render correctly 1`] = `
         class="MuiBox-root css-1423sdf"
       >
         <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary css-18qluo-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-icon MuiButton-startIcon css-1sh91j5-MuiButton-startIcon"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+              data-testid="ShareOutlinedIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92s2.92-1.31 2.92-2.92-1.31-2.92-2.92-2.92M18 4c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1M6 13c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1m12 7.02c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1"
+              />
+            </svg>
+          </span>
+          Share
+        </button>
+        <button
           class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary css-160ospa-MuiButtonBase-root-MuiButton-root"
           tabindex="0"
           type="button"
@@ -2553,20 +2575,20 @@ exports[`App > should render correctly 1`] = `
                   tabindex="0"
                 >
                   <div
-                    id="voiceover-_r_28_-1"
+                    id="voiceover-_r_29_-1"
                     style="display: none;"
                   />
                   <div
-                    id="voiceover-_r_28_-2"
+                    id="voiceover-_r_29_-2"
                     style="display: none;"
                   />
                   <div
-                    aria-labelledby="voiceover-_r_28_-1"
+                    aria-labelledby="voiceover-_r_29_-1"
                     role="img"
                     style="width: 100%; height: 100%; outline: none;"
                   />
                   <div
-                    aria-labelledby="voiceover-_r_28_-2"
+                    aria-labelledby="voiceover-_r_29_-2"
                     role="img"
                     style="width: 100%; height: 100%; outline: none;"
                   />
@@ -2658,7 +2680,7 @@ exports[`App > should render correctly 1`] = `
                     />
                   </g>
                   <g
-                    clip-path="url(#_r_27_-clip-path)"
+                    clip-path="url(#_r_28_-clip-path)"
                   >
                     <g
                       class="MuiLineChart-areaPlot css-94vonx-MuiAreaPlot-root"
@@ -2667,7 +2689,7 @@ exports[`App > should render correctly 1`] = `
                       class="MuiLineChart-linePlot css-1ygpbzp-MuiLinePlot-root"
                     >
                       <clippath
-                        id="_r_28_-uob-one-account-line-clip"
+                        id="_r_29_-uob-one-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2678,7 +2700,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_28_-uob-one-account-line-clip)"
+                        clip-path="url(#_r_29_-uob-one-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2694,7 +2716,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_28_-ocbc-360-account-line-clip"
+                        id="_r_29_-ocbc-360-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2705,7 +2727,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_28_-ocbc-360-account-line-clip)"
+                        clip-path="url(#_r_29_-ocbc-360-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2721,7 +2743,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_28_-mari-savings-account-line-clip"
+                        id="_r_29_-mari-savings-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2732,7 +2754,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_28_-mari-savings-account-line-clip)"
+                        clip-path="url(#_r_29_-mari-savings-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2748,7 +2770,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_28_-standard-chartered-bonus-saver-line-clip"
+                        id="_r_29_-standard-chartered-bonus-saver-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2759,7 +2781,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_28_-standard-chartered-bonus-saver-line-clip)"
+                        clip-path="url(#_r_29_-standard-chartered-bonus-saver-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2775,7 +2797,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_28_-trust-bank-signature-line-clip"
+                        id="_r_29_-trust-bank-signature-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2786,7 +2808,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_28_-trust-bank-signature-line-clip)"
+                        clip-path="url(#_r_29_-trust-bank-signature-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2802,7 +2824,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_28_-trust-bank-zen-line-clip"
+                        id="_r_29_-trust-bank-zen-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2813,7 +2835,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_28_-trust-bank-zen-line-clip)"
+                        clip-path="url(#_r_29_-trust-bank-zen-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2829,7 +2851,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_28_-dbs-multiplier-account-line-clip"
+                        id="_r_29_-dbs-multiplier-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2840,7 +2862,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_28_-dbs-multiplier-account-line-clip)"
+                        clip-path="url(#_r_29_-dbs-multiplier-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2856,7 +2878,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_28_-gxs-savings-account-line-clip"
+                        id="_r_29_-gxs-savings-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2867,7 +2889,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_28_-gxs-savings-account-line-clip)"
+                        clip-path="url(#_r_29_-gxs-savings-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2883,7 +2905,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_28_-chocolate-finance-line-clip"
+                        id="_r_29_-chocolate-finance-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2894,7 +2916,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_28_-chocolate-finance-line-clip)"
+                        clip-path="url(#_r_29_-chocolate-finance-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2910,7 +2932,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_28_-boc-supersaver-line-clip"
+                        id="_r_29_-boc-supersaver-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2921,7 +2943,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_28_-boc-supersaver-line-clip)"
+                        clip-path="url(#_r_29_-boc-supersaver-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2937,7 +2959,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_28_-maybank-saveup-line-clip"
+                        id="_r_29_-maybank-saveup-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2948,7 +2970,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_28_-maybank-saveup-line-clip)"
+                        clip-path="url(#_r_29_-maybank-saveup-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2964,7 +2986,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_28_-maybank-isavvy-line-clip"
+                        id="_r_29_-maybank-isavvy-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2975,7 +2997,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_28_-maybank-isavvy-line-clip)"
+                        clip-path="url(#_r_29_-maybank-isavvy-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2991,7 +3013,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_28_-maybank-isavvy-plus-line-clip"
+                        id="_r_29_-maybank-isavvy-plus-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -3002,7 +3024,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_28_-maybank-isavvy-plus-line-clip)"
+                        clip-path="url(#_r_29_-maybank-isavvy-plus-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -3018,7 +3040,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_28_-citi-wealth-first-account-line-clip"
+                        id="_r_29_-citi-wealth-first-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -3029,7 +3051,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_28_-citi-wealth-first-account-line-clip)"
+                        clip-path="url(#_r_29_-citi-wealth-first-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -3390,65 +3412,65 @@ exports[`App > should render correctly 1`] = `
                       class="MuiLineChart-markPlot css-1xks5uz-MuiMarkPlot-root"
                     >
                       <g
-                        clip-path="url(#_r_28_-uob-one-account-line-clip)"
+                        clip-path="url(#_r_29_-uob-one-account-line-clip)"
                         data-series="uob-one-account"
                       />
                       <g
-                        clip-path="url(#_r_28_-ocbc-360-account-line-clip)"
+                        clip-path="url(#_r_29_-ocbc-360-account-line-clip)"
                         data-series="ocbc-360-account"
                       />
                       <g
-                        clip-path="url(#_r_28_-mari-savings-account-line-clip)"
+                        clip-path="url(#_r_29_-mari-savings-account-line-clip)"
                         data-series="mari-savings-account"
                       />
                       <g
-                        clip-path="url(#_r_28_-standard-chartered-bonus-saver-line-clip)"
+                        clip-path="url(#_r_29_-standard-chartered-bonus-saver-line-clip)"
                         data-series="standard-chartered-bonus-saver"
                       />
                       <g
-                        clip-path="url(#_r_28_-trust-bank-signature-line-clip)"
+                        clip-path="url(#_r_29_-trust-bank-signature-line-clip)"
                         data-series="trust-bank-signature"
                       />
                       <g
-                        clip-path="url(#_r_28_-trust-bank-zen-line-clip)"
+                        clip-path="url(#_r_29_-trust-bank-zen-line-clip)"
                         data-series="trust-bank-zen"
                       />
                       <g
-                        clip-path="url(#_r_28_-dbs-multiplier-account-line-clip)"
+                        clip-path="url(#_r_29_-dbs-multiplier-account-line-clip)"
                         data-series="dbs-multiplier-account"
                       />
                       <g
-                        clip-path="url(#_r_28_-gxs-savings-account-line-clip)"
+                        clip-path="url(#_r_29_-gxs-savings-account-line-clip)"
                         data-series="gxs-savings-account"
                       />
                       <g
-                        clip-path="url(#_r_28_-chocolate-finance-line-clip)"
+                        clip-path="url(#_r_29_-chocolate-finance-line-clip)"
                         data-series="chocolate-finance"
                       />
                       <g
-                        clip-path="url(#_r_28_-boc-supersaver-line-clip)"
+                        clip-path="url(#_r_29_-boc-supersaver-line-clip)"
                         data-series="boc-supersaver"
                       />
                       <g
-                        clip-path="url(#_r_28_-maybank-saveup-line-clip)"
+                        clip-path="url(#_r_29_-maybank-saveup-line-clip)"
                         data-series="maybank-saveup"
                       />
                       <g
-                        clip-path="url(#_r_28_-maybank-isavvy-line-clip)"
+                        clip-path="url(#_r_29_-maybank-isavvy-line-clip)"
                         data-series="maybank-isavvy"
                       />
                       <g
-                        clip-path="url(#_r_28_-maybank-isavvy-plus-line-clip)"
+                        clip-path="url(#_r_29_-maybank-isavvy-plus-line-clip)"
                         data-series="maybank-isavvy-plus"
                       />
                       <g
-                        clip-path="url(#_r_28_-citi-wealth-first-account-line-clip)"
+                        clip-path="url(#_r_29_-citi-wealth-first-account-line-clip)"
                         data-series="citi-wealth-first-account"
                       />
                     </g>
                   </g>
                   <clippath
-                    id="_r_27_-clip-path"
+                    id="_r_28_-clip-path"
                   >
                     <rect
                       height="415"

--- a/src/__snapshots__/App.test.tsx.snap
+++ b/src/__snapshots__/App.test.tsx.snap
@@ -112,67 +112,6 @@ exports[`App > should render correctly 1`] = `
       class="MuiContainer-root MuiContainer-maxWidthLg css-5c1adp-MuiContainer-root"
     >
       <div
-        class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-cwrbtg-MuiCollapse-root"
-        style="min-height: 0px;"
-      >
-        <div
-          class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
-        >
-          <div
-            class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
-          >
-            <div
-              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standard css-toknla-MuiPaper-root-MuiAlert-root"
-              role="alert"
-              style="--Paper-shadow: none; --Paper-overlay: linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 0));"
-            >
-              <div
-                class="MuiAlert-icon css-vab54s-MuiAlert-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1ckov0h-MuiSvgIcon-root"
-                  data-testid="ReportProblemOutlinedIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
-                  />
-                </svg>
-              </div>
-              <div
-                class="MuiAlert-message css-zioonp-MuiAlert-message"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body2 css-7mxp11-MuiTypography-root"
-                >
-                  Shared profile detected — 0 fields differ
-                </p>
-              </div>
-              <div
-                class="MuiAlert-action css-rgppqo-MuiAlert-action"
-              >
-                <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeSmall MuiButton-colorInherit css-1x7rj9k-MuiButtonBase-root-MuiButton-root"
-                  tabindex="0"
-                  type="button"
-                >
-                  Keep mine
-                </button>
-                <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-sizeSmall MuiButton-colorPrimary css-122qsav-MuiButtonBase-root-MuiButton-root"
-                  tabindex="0"
-                  type="button"
-                >
-                  Load
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
         class="MuiFormControl-root css-1hr5jum-MuiFormControl-root"
       >
         <div
@@ -184,8 +123,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_5_"
-              id="_r_5_-label"
+              for="_r_4_"
+              id="_r_4_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -203,7 +142,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_5_"
+                id="_r_4_"
                 placeholder="To be deposited at bank"
                 type="number"
                 value=""
@@ -236,8 +175,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_6_"
-              id="_r_6_-label"
+              for="_r_5_"
+              id="_r_5_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -255,7 +194,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_6_"
+                id="_r_5_"
                 placeholder="Current age"
                 type="number"
                 value=""
@@ -288,8 +227,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_7_"
-              id="_r_7_-label"
+              for="_r_6_"
+              id="_r_6_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -307,7 +246,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_7_"
+                id="_r_6_"
                 placeholder="Credited to bank monthly"
                 type="number"
                 value=""
@@ -340,8 +279,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_8_"
-              id="_r_8_-label"
+              for="_r_7_"
+              id="_r_7_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -359,7 +298,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_8_"
+                id="_r_7_"
                 placeholder="Pay to bank yearly"
                 type="number"
                 value=""
@@ -392,8 +331,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_9_"
-              id="_r_9_-label"
+              for="_r_8_"
+              id="_r_8_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -411,7 +350,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_9_"
+                id="_r_8_"
                 placeholder="Pay to bank yearly"
                 type="number"
                 value=""
@@ -444,8 +383,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_a_"
-              id="_r_a_-label"
+              for="_r_9_"
+              id="_r_9_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -463,7 +402,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_a_"
+                id="_r_9_"
                 placeholder="On eligible cards monthly"
                 type="number"
                 value=""
@@ -496,8 +435,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_b_"
-              id="_r_b_-label"
+              for="_r_a_"
+              id="_r_a_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -515,7 +454,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_b_"
+                id="_r_a_"
                 placeholder="No. of GIRO Transactions"
                 type="number"
                 value=""
@@ -548,8 +487,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_c_"
-              id="_r_c_-label"
+              for="_r_b_"
+              id="_r_b_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -567,7 +506,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_c_"
+                id="_r_b_"
                 placeholder="Balance increase monthly"
                 type="number"
                 value=""
@@ -600,8 +539,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_d_"
-              id="_r_d_-label"
+              for="_r_c_"
+              id="_r_c_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -619,7 +558,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_d_"
+                id="_r_c_"
                 placeholder="Monthly loan payment"
                 type="number"
                 value=""
@@ -652,8 +591,8 @@ exports[`App > should render correctly 1`] = `
             <label
               class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined css-g1crgq-MuiFormLabel-root-MuiInputLabel-root"
               data-shrink="false"
-              for="_r_e_"
-              id="_r_e_-label"
+              for="_r_d_"
+              id="_r_d_-label"
             >
               <div
                 style="display: flex; flex-direction: row;"
@@ -671,7 +610,7 @@ exports[`App > should render correctly 1`] = `
               <input
                 aria-invalid="false"
                 class="MuiInputBase-input MuiOutlinedInput-input css-j3jqhj-MuiInputBase-input-MuiOutlinedInput-input"
-                id="_r_e_"
+                id="_r_d_"
                 placeholder="Additional 1 time loan"
                 type="number"
                 value=""
@@ -2636,20 +2575,20 @@ exports[`App > should render correctly 1`] = `
                   tabindex="0"
                 >
                   <div
-                    id="voiceover-_r_2b_-1"
+                    id="voiceover-_r_2a_-1"
                     style="display: none;"
                   />
                   <div
-                    id="voiceover-_r_2b_-2"
+                    id="voiceover-_r_2a_-2"
                     style="display: none;"
                   />
                   <div
-                    aria-labelledby="voiceover-_r_2b_-1"
+                    aria-labelledby="voiceover-_r_2a_-1"
                     role="img"
                     style="width: 100%; height: 100%; outline: none;"
                   />
                   <div
-                    aria-labelledby="voiceover-_r_2b_-2"
+                    aria-labelledby="voiceover-_r_2a_-2"
                     role="img"
                     style="width: 100%; height: 100%; outline: none;"
                   />
@@ -2741,7 +2680,7 @@ exports[`App > should render correctly 1`] = `
                     />
                   </g>
                   <g
-                    clip-path="url(#_r_2a_-clip-path)"
+                    clip-path="url(#_r_29_-clip-path)"
                   >
                     <g
                       class="MuiLineChart-areaPlot css-94vonx-MuiAreaPlot-root"
@@ -2750,7 +2689,7 @@ exports[`App > should render correctly 1`] = `
                       class="MuiLineChart-linePlot css-1ygpbzp-MuiLinePlot-root"
                     >
                       <clippath
-                        id="_r_2b_-uob-one-account-line-clip"
+                        id="_r_2a_-uob-one-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2761,7 +2700,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2b_-uob-one-account-line-clip)"
+                        clip-path="url(#_r_2a_-uob-one-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2777,7 +2716,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2b_-ocbc-360-account-line-clip"
+                        id="_r_2a_-ocbc-360-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2788,7 +2727,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2b_-ocbc-360-account-line-clip)"
+                        clip-path="url(#_r_2a_-ocbc-360-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2804,7 +2743,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2b_-mari-savings-account-line-clip"
+                        id="_r_2a_-mari-savings-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2815,7 +2754,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2b_-mari-savings-account-line-clip)"
+                        clip-path="url(#_r_2a_-mari-savings-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2831,7 +2770,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2b_-standard-chartered-bonus-saver-line-clip"
+                        id="_r_2a_-standard-chartered-bonus-saver-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2842,7 +2781,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2b_-standard-chartered-bonus-saver-line-clip)"
+                        clip-path="url(#_r_2a_-standard-chartered-bonus-saver-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2858,7 +2797,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2b_-trust-bank-signature-line-clip"
+                        id="_r_2a_-trust-bank-signature-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2869,7 +2808,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2b_-trust-bank-signature-line-clip)"
+                        clip-path="url(#_r_2a_-trust-bank-signature-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2885,7 +2824,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2b_-trust-bank-zen-line-clip"
+                        id="_r_2a_-trust-bank-zen-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2896,7 +2835,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2b_-trust-bank-zen-line-clip)"
+                        clip-path="url(#_r_2a_-trust-bank-zen-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2912,7 +2851,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2b_-dbs-multiplier-account-line-clip"
+                        id="_r_2a_-dbs-multiplier-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2923,7 +2862,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2b_-dbs-multiplier-account-line-clip)"
+                        clip-path="url(#_r_2a_-dbs-multiplier-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2939,7 +2878,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2b_-gxs-savings-account-line-clip"
+                        id="_r_2a_-gxs-savings-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2950,7 +2889,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2b_-gxs-savings-account-line-clip)"
+                        clip-path="url(#_r_2a_-gxs-savings-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2966,7 +2905,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2b_-chocolate-finance-line-clip"
+                        id="_r_2a_-chocolate-finance-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -2977,7 +2916,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2b_-chocolate-finance-line-clip)"
+                        clip-path="url(#_r_2a_-chocolate-finance-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -2993,7 +2932,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2b_-boc-supersaver-line-clip"
+                        id="_r_2a_-boc-supersaver-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -3004,7 +2943,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2b_-boc-supersaver-line-clip)"
+                        clip-path="url(#_r_2a_-boc-supersaver-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -3020,7 +2959,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2b_-maybank-saveup-line-clip"
+                        id="_r_2a_-maybank-saveup-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -3031,7 +2970,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2b_-maybank-saveup-line-clip)"
+                        clip-path="url(#_r_2a_-maybank-saveup-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -3047,7 +2986,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2b_-maybank-isavvy-line-clip"
+                        id="_r_2a_-maybank-isavvy-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -3058,7 +2997,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2b_-maybank-isavvy-line-clip)"
+                        clip-path="url(#_r_2a_-maybank-isavvy-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -3074,7 +3013,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2b_-maybank-isavvy-plus-line-clip"
+                        id="_r_2a_-maybank-isavvy-plus-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -3085,7 +3024,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2b_-maybank-isavvy-plus-line-clip)"
+                        clip-path="url(#_r_2a_-maybank-isavvy-plus-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -3101,7 +3040,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </g>
                       <clippath
-                        id="_r_2b_-citi-wealth-first-account-line-clip"
+                        id="_r_2a_-citi-wealth-first-account-line-clip"
                       >
                         <rect
                           class="css-dbuw8t"
@@ -3112,7 +3051,7 @@ exports[`App > should render correctly 1`] = `
                         />
                       </clippath>
                       <g
-                        clip-path="url(#_r_2b_-citi-wealth-first-account-line-clip)"
+                        clip-path="url(#_r_2a_-citi-wealth-first-account-line-clip)"
                       >
                         <path
                           class="MuiLineChart-line"
@@ -3473,65 +3412,65 @@ exports[`App > should render correctly 1`] = `
                       class="MuiLineChart-markPlot css-1xks5uz-MuiMarkPlot-root"
                     >
                       <g
-                        clip-path="url(#_r_2b_-uob-one-account-line-clip)"
+                        clip-path="url(#_r_2a_-uob-one-account-line-clip)"
                         data-series="uob-one-account"
                       />
                       <g
-                        clip-path="url(#_r_2b_-ocbc-360-account-line-clip)"
+                        clip-path="url(#_r_2a_-ocbc-360-account-line-clip)"
                         data-series="ocbc-360-account"
                       />
                       <g
-                        clip-path="url(#_r_2b_-mari-savings-account-line-clip)"
+                        clip-path="url(#_r_2a_-mari-savings-account-line-clip)"
                         data-series="mari-savings-account"
                       />
                       <g
-                        clip-path="url(#_r_2b_-standard-chartered-bonus-saver-line-clip)"
+                        clip-path="url(#_r_2a_-standard-chartered-bonus-saver-line-clip)"
                         data-series="standard-chartered-bonus-saver"
                       />
                       <g
-                        clip-path="url(#_r_2b_-trust-bank-signature-line-clip)"
+                        clip-path="url(#_r_2a_-trust-bank-signature-line-clip)"
                         data-series="trust-bank-signature"
                       />
                       <g
-                        clip-path="url(#_r_2b_-trust-bank-zen-line-clip)"
+                        clip-path="url(#_r_2a_-trust-bank-zen-line-clip)"
                         data-series="trust-bank-zen"
                       />
                       <g
-                        clip-path="url(#_r_2b_-dbs-multiplier-account-line-clip)"
+                        clip-path="url(#_r_2a_-dbs-multiplier-account-line-clip)"
                         data-series="dbs-multiplier-account"
                       />
                       <g
-                        clip-path="url(#_r_2b_-gxs-savings-account-line-clip)"
+                        clip-path="url(#_r_2a_-gxs-savings-account-line-clip)"
                         data-series="gxs-savings-account"
                       />
                       <g
-                        clip-path="url(#_r_2b_-chocolate-finance-line-clip)"
+                        clip-path="url(#_r_2a_-chocolate-finance-line-clip)"
                         data-series="chocolate-finance"
                       />
                       <g
-                        clip-path="url(#_r_2b_-boc-supersaver-line-clip)"
+                        clip-path="url(#_r_2a_-boc-supersaver-line-clip)"
                         data-series="boc-supersaver"
                       />
                       <g
-                        clip-path="url(#_r_2b_-maybank-saveup-line-clip)"
+                        clip-path="url(#_r_2a_-maybank-saveup-line-clip)"
                         data-series="maybank-saveup"
                       />
                       <g
-                        clip-path="url(#_r_2b_-maybank-isavvy-line-clip)"
+                        clip-path="url(#_r_2a_-maybank-isavvy-line-clip)"
                         data-series="maybank-isavvy"
                       />
                       <g
-                        clip-path="url(#_r_2b_-maybank-isavvy-plus-line-clip)"
+                        clip-path="url(#_r_2a_-maybank-isavvy-plus-line-clip)"
                         data-series="maybank-isavvy-plus"
                       />
                       <g
-                        clip-path="url(#_r_2b_-citi-wealth-first-account-line-clip)"
+                        clip-path="url(#_r_2a_-citi-wealth-first-account-line-clip)"
                         data-series="citi-wealth-first-account"
                       />
                     </g>
                   </g>
                   <clippath
-                    id="_r_2a_-clip-path"
+                    id="_r_29_-clip-path"
                   >
                     <rect
                       height="415"

--- a/src/__snapshots__/App.test.tsx.snap
+++ b/src/__snapshots__/App.test.tsx.snap
@@ -122,7 +122,7 @@ exports[`App > should render correctly 1`] = `
             class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
           >
             <div
-              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standard css-1sapdxe-MuiPaper-root-MuiAlert-root"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standard css-toknla-MuiPaper-root-MuiAlert-root"
               role="alert"
               style="--Paper-shadow: none; --Paper-overlay: linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 0));"
             >
@@ -144,7 +144,11 @@ exports[`App > should render correctly 1`] = `
               <div
                 class="MuiAlert-message css-zioonp-MuiAlert-message"
               >
-                Shared profile detected — load it?
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-7mxp11-MuiTypography-root"
+                >
+                  Shared profile detected — 0 fields differ
+                </p>
               </div>
               <div
                 class="MuiAlert-action css-rgppqo-MuiAlert-action"

--- a/src/logic/profileUrl.test.ts
+++ b/src/logic/profileUrl.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import { profileToSearch, searchToProfile, profileToUrl } from "./profileUrl";
+import { NewProfile } from "../types/profile";
+
+describe("profileToSearch", () => {
+  it("returns empty string for default profile", () => {
+    const profile = NewProfile({});
+    expect(profileToSearch(profile)).toBe("");
+  });
+
+  it("serializes non-default numeric fields with compact keys", () => {
+    const profile = NewProfile({ Savings: 50000, Salary: 6000, Spending: 500 });
+    const search = profileToSearch(profile);
+    expect(search).toContain("s=50000");
+    expect(search).toContain("sal=6000");
+    expect(search).toContain("sp=500");
+    expect(search.startsWith("?")).toBe(true);
+  });
+
+  it("omits fields at their default value", () => {
+    const profile = NewProfile({ Savings: 50000 });
+    const search = profileToSearch(profile);
+    expect(search).not.toContain("sal=");
+    expect(search).not.toContain("sp=");
+    expect(search).not.toContain("a=");
+  });
+
+  it("serializes boolean true fields", () => {
+    const profile = NewProfile({ IsNTUCMember: true });
+    expect(profileToSearch(profile)).toBe("?ntuc=1");
+  });
+
+  it("omits boolean false (default)", () => {
+    const profile = NewProfile({ IsNTUCMember: false });
+    expect(profileToSearch(profile)).toBe("");
+  });
+
+  it("serializes a fully populated profile", () => {
+    const profile = NewProfile({
+      Savings: 100000,
+      Age: 30,
+      Salary: 8000,
+      Spending: 2000,
+      Investment: 12000,
+      Insurance: 5000,
+      GiroTransactions: 3,
+      MonthlyAccIncrease: 1000,
+      LoanInstallment: 1500,
+      OneTimeLoan: 10000,
+      IsNTUCMember: true,
+    });
+    const search = profileToSearch(profile);
+    // All fields should be present
+    expect(search).toContain("s=100000");
+    expect(search).toContain("a=30");
+    expect(search).toContain("sal=8000");
+    expect(search).toContain("sp=2000");
+    expect(search).toContain("inv=12000");
+    expect(search).toContain("ins=5000");
+    expect(search).toContain("giro=3");
+    expect(search).toContain("inc=1000");
+    expect(search).toContain("loan=1500");
+    expect(search).toContain("otl=10000");
+    expect(search).toContain("ntuc=1");
+  });
+});
+
+describe("searchToProfile", () => {
+  it("returns default profile for empty search", () => {
+    const result = searchToProfile("");
+    const defaults = NewProfile({});
+    expect(result).toEqual(defaults);
+  });
+
+  it("returns default profile for search with no recognized params", () => {
+    const result = searchToProfile("?foo=bar&baz=qux");
+    expect(result).toEqual(NewProfile({}));
+  });
+
+  it("parses numeric fields from search params", () => {
+    const result = searchToProfile("?s=50000&sal=6000&sp=500");
+    expect(result.Savings).toBe(50000);
+    expect(result.Salary).toBe(6000);
+    expect(result.Spending).toBe(500);
+  });
+
+  it("parses boolean fields", () => {
+    const withNtuc = searchToProfile("?ntuc=1");
+    expect(withNtuc.IsNTUCMember).toBe(true);
+
+    const withoutNtuc = searchToProfile("?ntuc=0");
+    expect(withoutNtuc.IsNTUCMember).toBe(false);
+  });
+
+  it("treats missing fields as defaults", () => {
+    const result = searchToProfile("?s=50000");
+    expect(result.Savings).toBe(50000);
+    expect(result.Salary).toBe(0);
+    expect(result.Spending).toBe(0);
+    expect(result.IsNTUCMember).toBe(false);
+  });
+
+  it("ignores negative values", () => {
+    const result = searchToProfile("?s=-500");
+    expect(result.Savings).toBe(0); // default, negative ignored
+  });
+
+  it("ignores non-numeric values", () => {
+    const result = searchToProfile("?s=abc");
+    expect(result.Savings).toBe(0); // default, non-numeric ignored
+  });
+
+  it("handles search with or without leading ?", () => {
+    const withQ = searchToProfile("?s=42");
+    const withoutQ = searchToProfile("s=42");
+    expect(withQ.Savings).toBe(42);
+    expect(withoutQ.Savings).toBe(42);
+  });
+});
+
+describe("profileToSearch → searchToProfile round-trip", () => {
+  it("preserves all fields for a fully populated profile", () => {
+    const original = NewProfile({
+      Savings: 75000,
+      Age: 28,
+      Salary: 5500,
+      Spending: 1200,
+      Investment: 8000,
+      Insurance: 3600,
+      GiroTransactions: 2,
+      MonthlyAccIncrease: 500,
+      LoanInstallment: 2000,
+      OneTimeLoan: 5000,
+      IsNTUCMember: true,
+    });
+    const roundTripped = searchToProfile(profileToSearch(original));
+    expect(roundTripped).toEqual(original);
+  });
+
+  it("preserves profile with only some fields set", () => {
+    const original = NewProfile({ Savings: 20000, Salary: 4000 });
+    const roundTripped = searchToProfile(profileToSearch(original));
+    expect(roundTripped).toEqual(original);
+  });
+});

--- a/src/logic/profileUrl.test.ts
+++ b/src/logic/profileUrl.test.ts
@@ -8,26 +8,26 @@ describe("profileToSearch", () => {
     expect(profileToSearch(profile)).toBe("");
   });
 
-  it("serializes non-default numeric fields with compact keys", () => {
+  it("serializes non-default numeric fields using field names as keys", () => {
     const profile = NewProfile({ Savings: 50000, Salary: 6000, Spending: 500 });
     const search = profileToSearch(profile);
-    expect(search).toContain("s=50000");
-    expect(search).toContain("sal=6000");
-    expect(search).toContain("sp=500");
+    expect(search).toContain("Savings=50000");
+    expect(search).toContain("Salary=6000");
+    expect(search).toContain("Spending=500");
     expect(search.startsWith("?")).toBe(true);
   });
 
   it("omits fields at their default value", () => {
     const profile = NewProfile({ Savings: 50000 });
     const search = profileToSearch(profile);
-    expect(search).not.toContain("sal=");
-    expect(search).not.toContain("sp=");
-    expect(search).not.toContain("a=");
+    expect(search).not.toContain("Salary=");
+    expect(search).not.toContain("Spending=");
+    expect(search).not.toContain("Age=");
   });
 
   it("serializes boolean true fields", () => {
     const profile = NewProfile({ IsNTUCMember: true });
-    expect(profileToSearch(profile)).toBe("?ntuc=1");
+    expect(profileToSearch(profile)).toBe("?IsNTUCMember=1");
   });
 
   it("omits boolean false (default)", () => {
@@ -51,17 +51,17 @@ describe("profileToSearch", () => {
     });
     const search = profileToSearch(profile);
     // All fields should be present
-    expect(search).toContain("s=100000");
-    expect(search).toContain("a=30");
-    expect(search).toContain("sal=8000");
-    expect(search).toContain("sp=2000");
-    expect(search).toContain("inv=12000");
-    expect(search).toContain("ins=5000");
-    expect(search).toContain("giro=3");
-    expect(search).toContain("inc=1000");
-    expect(search).toContain("loan=1500");
-    expect(search).toContain("otl=10000");
-    expect(search).toContain("ntuc=1");
+    expect(search).toContain("Savings=100000");
+    expect(search).toContain("Age=30");
+    expect(search).toContain("Salary=8000");
+    expect(search).toContain("Spending=2000");
+    expect(search).toContain("Investment=12000");
+    expect(search).toContain("Insurance=5000");
+    expect(search).toContain("GiroTransactions=3");
+    expect(search).toContain("MonthlyAccIncrease=1000");
+    expect(search).toContain("LoanInstallment=1500");
+    expect(search).toContain("OneTimeLoan=10000");
+    expect(search).toContain("IsNTUCMember=1");
   });
 });
 
@@ -78,22 +78,22 @@ describe("searchToProfile", () => {
   });
 
   it("parses numeric fields from search params", () => {
-    const result = searchToProfile("?s=50000&sal=6000&sp=500");
+    const result = searchToProfile("?Savings=50000&Salary=6000&Spending=500");
     expect(result.Savings).toBe(50000);
     expect(result.Salary).toBe(6000);
     expect(result.Spending).toBe(500);
   });
 
   it("parses boolean fields", () => {
-    const withNtuc = searchToProfile("?ntuc=1");
+    const withNtuc = searchToProfile("?IsNTUCMember=1");
     expect(withNtuc.IsNTUCMember).toBe(true);
 
-    const withoutNtuc = searchToProfile("?ntuc=0");
+    const withoutNtuc = searchToProfile("?IsNTUCMember=0");
     expect(withoutNtuc.IsNTUCMember).toBe(false);
   });
 
   it("treats missing fields as defaults", () => {
-    const result = searchToProfile("?s=50000");
+    const result = searchToProfile("?Savings=50000");
     expect(result.Savings).toBe(50000);
     expect(result.Salary).toBe(0);
     expect(result.Spending).toBe(0);
@@ -101,18 +101,18 @@ describe("searchToProfile", () => {
   });
 
   it("ignores negative values", () => {
-    const result = searchToProfile("?s=-500");
+    const result = searchToProfile("?Savings=-500");
     expect(result.Savings).toBe(0); // default, negative ignored
   });
 
   it("ignores non-numeric values", () => {
-    const result = searchToProfile("?s=abc");
+    const result = searchToProfile("?Savings=abc");
     expect(result.Savings).toBe(0); // default, non-numeric ignored
   });
 
   it("handles search with or without leading ?", () => {
-    const withQ = searchToProfile("?s=42");
-    const withoutQ = searchToProfile("s=42");
+    const withQ = searchToProfile("?Savings=42");
+    const withoutQ = searchToProfile("Savings=42");
     expect(withQ.Savings).toBe(42);
     expect(withoutQ.Savings).toBe(42);
   });

--- a/src/logic/profileUrl.ts
+++ b/src/logic/profileUrl.ts
@@ -1,51 +1,28 @@
 import type Profile from "../types/profile";
 import { NewProfile } from "../types/profile";
 
-/**
- * Map of Profile field names to compact URL parameter keys.
- * Order: most commonly shared fields first for nicer URLs.
- */
-const FIELD_TO_PARAM: Record<keyof Profile, string> = {
-  Savings: "s",
-  Salary: "sal",
-  Spending: "sp",
-  Age: "a",
-  Investment: "inv",
-  Insurance: "ins",
-  GiroTransactions: "giro",
-  MonthlyAccIncrease: "inc",
-  LoanInstallment: "loan",
-  OneTimeLoan: "otl",
-  IsNTUCMember: "ntuc",
-};
+/** All Profile field names, derived from the type at runtime. */
+const PROFILE_FIELDS = Object.keys(NewProfile({})) as (keyof Profile)[];
 
-/** Reverse map: param key → Profile field name */
-const PARAM_TO_FIELD: Record<string, keyof Profile> = Object.fromEntries(
-  Object.entries(FIELD_TO_PARAM).map(([field, param]) => [param, field as keyof Profile]),
-);
-
-const defaultProfile = NewProfile({});
-
-/** Whether a field value is at its default (and can be omitted from the URL). */
-const isDefault = (field: keyof Profile, value: number | boolean): boolean => {
-  return value === defaultProfile[field];
-};
+const defaults = NewProfile({});
 
 /**
  * Serialize a Profile to a query string, omitting fields at their default values.
  * Returns only the `?key=value` portion (or empty string if nothing to serialize).
+ *
+ * Uses the Profile field name directly as the URL parameter key (e.g. ?Savings=50000).
  */
 export const profileToSearch = (profile: Profile): string => {
   const params = new URLSearchParams();
 
-  for (const field of Object.keys(FIELD_TO_PARAM) as (keyof Profile)[]) {
+  for (const field of PROFILE_FIELDS) {
     const value = profile[field];
-    if (isDefault(field, value)) continue;
+    if (value === defaults[field]) continue;
 
     if (typeof value === "boolean") {
-      if (value) params.set(FIELD_TO_PARAM[field], "1");
+      params.set(field, value ? "1" : "0");
     } else {
-      params.set(FIELD_TO_PARAM[field], String(value));
+      params.set(field, String(value));
     }
   }
 
@@ -56,6 +33,9 @@ export const profileToSearch = (profile: Profile): string => {
 /**
  * Parse a raw query string (with or without leading `?`) into a Profile,
  * merging with defaults for any missing fields.
+ *
+ * Only URL params whose key matches a Profile field name are processed —
+ * unrecognized params are silently ignored.
  */
 export const searchToProfile = (rawSearch: string): Profile => {
   const params = new URLSearchParams(
@@ -64,13 +44,12 @@ export const searchToProfile = (rawSearch: string): Profile => {
 
   const profile = NewProfile({});
 
-  for (const paramKey of Object.keys(PARAM_TO_FIELD)) {
-    const raw = params.get(paramKey);
+  for (const field of PROFILE_FIELDS) {
+    const raw = params.get(field);
     if (raw === null) continue;
 
-    const field = PARAM_TO_FIELD[paramKey];
     const num = Number(raw);
-    if (isNaN(num) || num < 0) continue; // ignore non-numeric / negative values
+    if (isNaN(num) || num < 0) continue;
 
     if (typeof profile[field] === "boolean") {
       (profile as unknown as Record<string, unknown>)[field] = num !== 0;

--- a/src/logic/profileUrl.ts
+++ b/src/logic/profileUrl.ts
@@ -1,0 +1,93 @@
+import type Profile from "../types/profile";
+import { NewProfile } from "../types/profile";
+
+/**
+ * Map of Profile field names to compact URL parameter keys.
+ * Order: most commonly shared fields first for nicer URLs.
+ */
+const FIELD_TO_PARAM: Record<keyof Profile, string> = {
+  Savings: "s",
+  Salary: "sal",
+  Spending: "sp",
+  Age: "a",
+  Investment: "inv",
+  Insurance: "ins",
+  GiroTransactions: "giro",
+  MonthlyAccIncrease: "inc",
+  LoanInstallment: "loan",
+  OneTimeLoan: "otl",
+  IsNTUCMember: "ntuc",
+};
+
+/** Reverse map: param key → Profile field name */
+const PARAM_TO_FIELD: Record<string, keyof Profile> = Object.fromEntries(
+  Object.entries(FIELD_TO_PARAM).map(([field, param]) => [param, field as keyof Profile]),
+);
+
+const defaultProfile = NewProfile({});
+
+/** Whether a field value is at its default (and can be omitted from the URL). */
+const isDefault = (field: keyof Profile, value: number | boolean): boolean => {
+  return value === defaultProfile[field];
+};
+
+/**
+ * Serialize a Profile to a query string, omitting fields at their default values.
+ * Returns only the `?key=value` portion (or empty string if nothing to serialize).
+ */
+export const profileToSearch = (profile: Profile): string => {
+  const params = new URLSearchParams();
+
+  for (const field of Object.keys(FIELD_TO_PARAM) as (keyof Profile)[]) {
+    const value = profile[field];
+    if (isDefault(field, value)) continue;
+
+    if (typeof value === "boolean") {
+      if (value) params.set(FIELD_TO_PARAM[field], "1");
+    } else {
+      params.set(FIELD_TO_PARAM[field], String(value));
+    }
+  }
+
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
+};
+
+/**
+ * Parse a raw query string (with or without leading `?`) into a Profile,
+ * merging with defaults for any missing fields.
+ */
+export const searchToProfile = (rawSearch: string): Profile => {
+  const params = new URLSearchParams(
+    rawSearch.startsWith("?") ? rawSearch.slice(1) : rawSearch,
+  );
+
+  const profile = NewProfile({});
+
+  for (const paramKey of Object.keys(PARAM_TO_FIELD)) {
+    const raw = params.get(paramKey);
+    if (raw === null) continue;
+
+    const field = PARAM_TO_FIELD[paramKey];
+    const num = Number(raw);
+    if (isNaN(num) || num < 0) continue; // ignore non-numeric / negative values
+
+    if (typeof profile[field] === "boolean") {
+      (profile as unknown as Record<string, unknown>)[field] = num !== 0;
+    } else {
+      (profile as unknown as Record<string, unknown>)[field] = num;
+    }
+  }
+
+  return profile;
+};
+
+/**
+ * Serialize a Profile to a full shareable URL (absolute).
+ */
+export const profileToUrl = (profile: Profile): string => {
+  const origin = window.location.origin;
+  const pathname = window.location.pathname;
+  const search = profileToSearch(profile);
+  return `${origin}${pathname}${search}`;
+};


### PR DESCRIPTION
Serialize profile state to URL query params so users can share ('check out what I get') and bookmark their setup.

- New profileUrl.ts: compact serialization/deserialization with round-trip fidelity; omits default-valued fields for clean URLs
- App.tsx: URL params override localStorage on load; URL stays in sync via replaceState as profile changes
- New ShareButton component: clipboard copy with fallback and visual feedback (ShareOutline → checkmark)
- 16 unit tests for serialization logic; 3 snapshots updated
- All 304 tests pass

This MR is created by Picoclaw